### PR TITLE
Ansible: use distro db users for cron

### DIFF
--- a/scripts/ansible/asm_install.yml
+++ b/scripts/ansible/asm_install.yml
@@ -106,15 +106,4 @@
           - "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}/templates/asm/cron.sh"
           - "{{ inventory_dir }}/group_vars/asm/templates/cron.sh"
           - "{{  playbook_dir }}/templates/cron.sh"
-
-    - name: "Configure backup credentials"
-      template:
-        src: "{{ lookup('first_found', paths ) }}"
-        dest: "/etc/cron.daily/backup.d/asm.cnf"
-        mode: "0600"
-      vars:
-        paths:
-          - "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}/templates/asm/backup.cnf"
-          - "{{ inventory_dir }}/group_vars/asm/templates/backup.cnf"
-          - "{{  playbook_dir }}/templates/backup.cnf"
 ...

--- a/scripts/ansible/templates/backup.cnf
+++ b/scripts/ansible/templates/backup.cnf
@@ -1,7 +1,0 @@
-{% if asm_db.type=='POSTGRESQL' %}
-{{ asm_db.host }}:{{ asm_db.port }}:{{ asm_db.name }}:{{ asm_db.user }}:{{ asm_db.pass|replace(":", "\\:") }}
-{% elif asm_db.type=='MYSQL' %}
-[mysqldump]
-user={{ asm_db.user }}
-password={{ asm_db.pass }}
-{% endif %}

--- a/scripts/ansible/templates/cron.sh
+++ b/scripts/ansible/templates/cron.sh
@@ -5,7 +5,6 @@
 ASM_PATH={{ asm_path }}
 ASM_DATA={{ asm_data }}
 
-BACKUP_CNF=/etc/cron.daily/backup.d/asm.cnf
 BACKUP_DIR=/srv/backups/asm
 
 DB_HOST={{ asm_db.host }}
@@ -31,9 +30,9 @@ today=`date +%F`
 
 # Dump the database
 {% if   asm_db.type == 'POSTGRESQL' %}
-PGPASSFILE=$BACKUP_CNF pg_dump -w -U $DB_USER -h $DB_HOST -d $DB_NAME -p $DB_PORT > $ASM_DATA/$DB_NAME.sql
+sudo -u postgres pg_dump > $DB_NAME > $ASM_DATA/$DB_NAME.sql
 {% elif asm_db.type == 'MYSQL' %}
-mysqldump --defaults-extra-file=$BACKUP_CNF $DB_NAME > $ASM_DATA/$DB_NAME.sql
+mysqldump --defaults-extra-file=/etc/mysql/debian $DB_NAME > $ASM_DATA/$DB_NAME.sql
 {% endif %}
 
 cd $ASM_DATA


### PR DESCRIPTION
Use the distro provided root users for databases to save database dumps for backups.

Updates #1343