### PR TITLE
Audit trail for on donor record with media is moved

### DIFF
--- a/src/asm3/media.py
+++ b/src/asm3/media.py
@@ -861,11 +861,16 @@ def clone_media(dbo: Database, username: str, mediaid: int, linktypeid: int, lin
 
 def update_media_link(dbo: Database, username: str, mediaid: int, linktypeid: int, linkid: int) -> None:
     """ Updates the media with id to have a new link """
+    row = asm3.media.get_media_by_id(dbo, mediaid)
+    parentlinks = asm3.audit.get_parent_links(row, "media")
+    message = f"{mediaid} moved to linktype={linktypeid} linkid={linkid}"
+    asm3.audit.edit(dbo, username, "media", linkid, parentlinks, message)
     dbo.update("media", mediaid, {
         "LinkID":   linkid,
         "LinkTypeID": linktypeid,
         "Date":     dbo.now()
     }, username)
+    
 
 def delete_media(dbo: Database, username: str, mid: int) -> None:
     """

--- a/src/main.py
+++ b/src/main.py
@@ -3561,8 +3561,7 @@ class document_templates(JSONEndpoint):
         templates = asm3.template.get_document_templates(o.dbo)
         asm3.al.debug("got %d document templates" % len(templates), "main.document_templates", o.dbo)
         return {
-            "rows": templates,
-            "defaults": asm3.template.get_document_templates_defaults(o.dbo)
+            "rows": templates
         }
 
     def post_create(self, o):
@@ -3575,11 +3574,6 @@ class document_templates(JSONEndpoint):
     def post_delete(self, o):
         for t in o.post.integer_list("ids"):
             asm3.template.delete_document_template(o.dbo, o.user, t)
-
-    def post_reload(self, o):
-        for name in o.post["names"].split(","):
-            content = asm3.utils.read_binary_file(f"{PATH}media/templates/{name}")
-            asm3.template.create_document_template(o.dbo, o.user, name, show="nowhere", content=content)
 
     def post_rename(self, o):
         asm3.template.rename_document_template(o.dbo, o.user, o.post.integer("dtid"), o.post["newname"])


### PR DESCRIPTION
An audit trail is left on the donor animal/owner record when media is moved to another record. #1622