### PR TITLE
add unsubscribe service and static unsubscribe page #1370

### DIFF
--- a/src/static/pages/successful_unsubscribe.html
+++ b/src/static/pages/successful_unsubscribe.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<title>Unsubscribed</title>
+</head>
+
+<body>
+
+<img src="../images/logo/icon-128.png" align="right" />
+
+<h1>Unsubscribed</h1>
+
+<p>You are now unsubscribed from emails.</p>
+
+<script>
+    window.scrollTo(0,0);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Add a service endpoint to unsubscribe from emails by setting the flag on the owner to be false for ExcludeFromBulkEmail and redirecting to a static unsubscribe page.

This pr does not include the work to add the UI changes to the merge email page, nor the necessary changes to _send_bulk_email to include an unsubscribe link.