### PR TITLE
templatedocument, templatehtml - saving to them writes to deletion table

### DIFF
--- a/src/asm3/dbms/base.py
+++ b/src/asm3/dbms/base.py
@@ -916,7 +916,6 @@ class Database(object):
         function that Writes an INSERT query for a result row
         """
         fields = []
-        donefields = False
         values = []
         for k in sorted(r.keys()):
             if not donefields:
@@ -929,7 +928,6 @@ class Database(object):
         """
         function that Writes an UPDATE query for a result row
         """
-        donefields = False # Don't know what the purpose of donefields is, code based on row_to_insert_sql(), left in as looked important - Adam.
         cdata = []
         rid = 0
         for k in sorted(r.keys()):

--- a/src/asm3/dbms/base.py
+++ b/src/asm3/dbms/base.py
@@ -918,10 +918,8 @@ class Database(object):
         fields = []
         values = []
         for k in sorted(r.keys()):
-            if not donefields:
-                fields.append(k)
+            fields.append(k)
             values.append(self.sql_value(r[k]))
-        donefields = True
         return "INSERT INTO %s (%s) VALUES (%s);\n" % (table, ",".join(fields), ",".join(values))
     
     def row_to_update_sql(self, table: str, r: ResultRow, uniquecol = "ID", escapeCR: str = "") -> str:
@@ -931,14 +929,12 @@ class Database(object):
         cdata = []
         rid = 0
         for k in sorted(r.keys()):
-            if not donefields:
-                if k == uniquecol:
-                    rid = self.sql_value(r[k])
-                elif k == "ID" and uniquecol != "ID":
-                    pass
-                else:
-                    cdata.append(k + " = " + self.sql_value(r[k]))
-        donefields = True
+            if k == uniquecol:
+                rid = self.sql_value(r[k])
+            elif k == "ID" and uniquecol != "ID":
+                pass
+            else:
+                cdata.append(k + " = " + self.sql_value(r[k]))
         return "UPDATE " + table + " SET " + ",".join(cdata) + " WHERE " + uniquecol + " = " + str(rid)
 
     def split_queries(self, sql: str) -> List[str]:

--- a/src/asm3/dbms/base.py
+++ b/src/asm3/dbms/base.py
@@ -924,6 +924,22 @@ class Database(object):
             values.append(self.sql_value(r[k]))
         donefields = True
         return "INSERT INTO %s (%s) VALUES (%s);\n" % (table, ",".join(fields), ",".join(values))
+    
+    def row_to_update_sql(self, table: str, r: ResultRow, escapeCR: str = "") -> str:
+        """
+        function that Writes an UPDATE query for a result row
+        """
+        donefields = False # Don't know what the purpose of donefields is, code based on row_to_insert_sql(), left in as looked important - Adam.
+        cdata = []
+        rid = 0
+        for k in sorted(r.keys()):
+            if not donefields:
+                if k == "ID":
+                    rid = self.sql_value(r[k])
+                else:
+                    cdata.append(k + " = " + self.sql_value(r[k]))
+        donefields = True
+        return "UPDATE " + table + " SET " + ",".join(cdata) + " WHERE ID = " + str(rid)
 
     def split_queries(self, sql: str) -> List[str]:
         """

--- a/src/asm3/dbms/base.py
+++ b/src/asm3/dbms/base.py
@@ -925,7 +925,7 @@ class Database(object):
         donefields = True
         return "INSERT INTO %s (%s) VALUES (%s);\n" % (table, ",".join(fields), ",".join(values))
     
-    def row_to_update_sql(self, table: str, r: ResultRow, escapeCR: str = "") -> str:
+    def row_to_update_sql(self, table: str, r: ResultRow, uniquecol = "ID", escapeCR: str = "") -> str:
         """
         function that Writes an UPDATE query for a result row
         """
@@ -934,12 +934,14 @@ class Database(object):
         rid = 0
         for k in sorted(r.keys()):
             if not donefields:
-                if k == "ID":
+                if k == uniquecol:
                     rid = self.sql_value(r[k])
+                elif k == "ID" and uniquecol != "ID":
+                    pass
                 else:
                     cdata.append(k + " = " + self.sql_value(r[k]))
         donefields = True
-        return "UPDATE " + table + " SET " + ",".join(cdata) + " WHERE ID = " + str(rid)
+        return "UPDATE " + table + " SET " + ",".join(cdata) + " WHERE " + uniquecol + " = " + str(rid)
 
     def split_queries(self, sql: str) -> List[str]:
         """

--- a/src/asm3/template.py
+++ b/src/asm3/template.py
@@ -148,10 +148,15 @@ def rename_document_template(dbo: Database, username: str, dtid: int, newname: s
 
 def update_document_template_content(dbo: Database, username: str, dtid: int, content: bytes) -> None:
     """ Changes the content of a template """
+    row = dbo.first_row(dbo.query("SELECT * FROM templatedocument WHERE ID = ?", (dtid,)))
+    sql = dbo.row_to_update_sql("templatedocument", row)
+
     dbo.update("templatedocument", dtid, {
         "Content":  asm3.utils.bytes2str(asm3.utils.base64encode(content))
     })
     name = get_document_template_name(dbo, dtid)
+
+    asm3.audit.insert_deletion(dbo, username, "templatedocument", dtid, "", sql)
     asm3.audit.edit(dbo, username, "templatedocument", dtid, "", "changed content of template %s (%s)" % (dtid, name))
 
 def update_document_template_show(dbo: Database, username: str, dtid: int, newshow: str) -> None:

--- a/src/asm3/template.py
+++ b/src/asm3/template.py
@@ -31,6 +31,8 @@ def get_html_template_names(dbo: Database) -> List[str]:
 
 def update_html_template(dbo: Database, username: str, name: str, head: str, body: str, foot: str, builtin: bool = False) -> None:
     """ Creates/updates an HTML publishing template """
+    row = dbo.first_row(dbo.query("SELECT * FROM templatehtml WHERE Name = ?", (name,)))
+    sql = dbo.row_to_update_sql("templatehtml", row, "NAME")
     dbo.execute("DELETE FROM templatehtml WHERE Name = ?", [name])
     htid = dbo.insert("templatehtml", {
         "Name":     name,
@@ -39,6 +41,9 @@ def update_html_template(dbo: Database, username: str, name: str, head: str, bod
         "*Footer":  foot,
         "IsBuiltIn": builtin and 1 or 0
     })
+
+    asm3.audit.insert_deletion(dbo, username, "templatehtml", row.ID, "", sql)
+
     asm3.audit.create(dbo, username, "templatehtml", htid, "", "id: %d, name: %s" % (htid, name))
 
 def delete_html_template(dbo: Database, username: str, name: str) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -3500,6 +3500,7 @@ class document_template_edit(ASMEndpoint):
         if sz > MAX_DOCUMENT_TEMPLATE_SIZE:
             raise asm3.utils.ASMValidationError(f"Error: {sz} > {MAX_DOCUMENT_TEMPLATE_SIZE}. Use extra images instead of pasting images.")
         dtid = post.integer("dtid")
+        
         asm3.template.update_document_template_content(dbo, o.user, dtid, post["document"])
         self.redirect("document_templates")
 

--- a/src/static/js/maint_undelete.js
+++ b/src/static/js/maint_undelete.js
@@ -14,7 +14,7 @@ $(function() {
                     header.show_loading(_("Loading..."));
                     try {
                         let result = await common.ajax_post("maint_undelete", "mode=view&key=" + row.KEY);
-                        $("#dialog-viewer-content").html(result); 
+                        $("#dialog-viewer-content").text(result); 
                         $("#dialog-viewer").dialog("open");
                     }
                     finally {


### PR DESCRIPTION
Working but html templates didn't fit nicely with the existing tools. The templates look to be assigned a new ID each time they're updated and the name must be unique. The restore button "winds back" templates as long as, for document templates - a template with the same ID, for html templates - a template with that name.