### PR TITLE
bugfix(onlineform): Added canafforddonation to the list of values that can translate to DB fields for waiting list import

### DIFF
--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -1841,6 +1841,7 @@ def create_waitinglist(dbo: Database, username: str, collationid: int) -> Tuple[
         if f.FIELDNAME == "description": d["description"] = f.VALUE
         if f.FIELDNAME == "reason": d["reasonforwantingtopart"] = f.VALUE
         if f.FIELDNAME == "comments": d["comments"] = f.VALUE
+        if f.FIELDNAME == "canafforddonation": d["canafforddonation"] = f.VALUE
         if f.FIELDNAME.startswith("additional"): d[f.FIELDNAME] = f.VALUE
     if "breed" not in d and "breed1" not in d: d["breed"] = guess_breed(dbo, "nomatchesusedefault")
     if "size" not in d: d["size"] = guess_size(dbo, "nomatchesusedefault")


### PR DESCRIPTION
It looks like most things were setup correctly for this happen correctly but the mapping to the "d" variable that is used to post to the database does not include the "canafforddonation" field. This prevented the value from being properly imported when creating a waiting list from an incoming form. 
