### PR TITLE
Custom auto increment scheme

### DIFF
--- a/src/asm3/additional.py
+++ b/src/asm3/additional.py
@@ -84,6 +84,7 @@ PERSON_SPONSOR = 11
 PERSON_VET = 12
 PERSON_ADOPTIONCOORDINATOR = 13
 TELEPHONE = 14
+NUMBER_INCREMENTED = 15
 
 def clause_for_linktype(linktype: str) -> str:
     """ Returns the appropriate clause for a link type """

--- a/src/asm3/additional.py
+++ b/src/asm3/additional.py
@@ -123,6 +123,10 @@ def is_person_fieldtype(fieldtype: int) -> bool:
     """ Returns true if the field type given is a person """
     return fieldtype in (PERSON_LOOKUP, PERSON_SPONSOR, PERSON_VET, PERSON_ADOPTIONCOORDINATOR)
 
+def get_next_additional_field_number(dbo: Database, afid: int) -> str:
+    """ Returns the next ID number for the frontend """
+    return dbo.get_id_cache_pk(f"additional_{afid}", "SELECT 1")
+
 def get_additional_fields(dbo: Database, linkid: int, linktype: str = "animal", linktypeid: int = -1) -> Results:
     """
     Returns a list of additional fields for the link
@@ -136,8 +140,11 @@ def get_additional_fields(dbo: Database, linkid: int, linktype: str = "animal", 
         inclause = f"({linktypeid})"
     else:
         inclause = clause_for_linktype(linktype)
+    nextadditionalid = dbo.get_id_cache_pk(f"additional_{linkid}", "SELECT 1")
+    #nextadditionalid = 666
     return dbo.query("SELECT af.*, a.Value, " \
         "CASE WHEN af.FieldType = 8 AND a.Value <> '' AND a.Value <> '0' THEN (SELECT AnimalName FROM animal WHERE %s = a.Value) ELSE '' END AS AnimalName, " \
+        #"CASE WHEN af.FieldType = 15 THEN %s END AS NumberIncrement, " \
         "CASE WHEN af.FieldType IN (9, 11, 12) AND a.Value <> '' AND a.Value <> '0' " \
             "THEN (SELECT OwnerName FROM owner WHERE %s = a.Value) ELSE '' END AS OwnerName " \
         "FROM additionalfield af " \

--- a/src/asm3/additional.py
+++ b/src/asm3/additional.py
@@ -140,11 +140,8 @@ def get_additional_fields(dbo: Database, linkid: int, linktype: str = "animal", 
         inclause = f"({linktypeid})"
     else:
         inclause = clause_for_linktype(linktype)
-    nextadditionalid = dbo.get_id_cache_pk(f"additional_{linkid}", "SELECT 1")
-    #nextadditionalid = 666
     return dbo.query("SELECT af.*, a.Value, " \
         "CASE WHEN af.FieldType = 8 AND a.Value <> '' AND a.Value <> '0' THEN (SELECT AnimalName FROM animal WHERE %s = a.Value) ELSE '' END AS AnimalName, " \
-        #"CASE WHEN af.FieldType = 15 THEN %s END AS NumberIncrement, " \
         "CASE WHEN af.FieldType IN (9, 11, 12) AND a.Value <> '' AND a.Value <> '0' " \
             "THEN (SELECT OwnerName FROM owner WHERE %s = a.Value) ELSE '' END AS OwnerName " \
         "FROM additionalfield af " \

--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -2611,6 +2611,7 @@ def sql_default_data(dbo: Database, skip_config: bool = False) -> str:
     sql += lookup1("lksfieldtype", "FieldType", 12, _("Vet"))
     sql += lookup1("lksfieldtype", "FieldType", 13, _("Adoption Coordinator"))
     sql += lookup1("lksfieldtype", "FieldType", 14, _("Telephone"))
+    sql += lookup1("lksfieldtype", "FieldType", 15, _("Number - Incrementing", l))
     sql += lookup1("lksloglink", "LinkType", 0, _("Animal", l))
     sql += lookup1("lksloglink", "LinkType", 1, _("Owner", l))
     sql += lookup1("lksloglink", "LinkType", 2, _("Lost Animal", l))

--- a/src/asm3/dbupdates/35013.py
+++ b/src/asm3/dbupdates/35013.py
@@ -1,0 +1,4 @@
+from asm3.dbupdate import execute
+
+execute(dbo, "INSERT INTO lksfieldtype (ID, FieldType) VALUES (?, ?)", [15, _("Number - Incrementing", dbo.locale)])
+

--- a/src/asm3/dbupdates/35013.py
+++ b/src/asm3/dbupdates/35013.py
@@ -1,4 +1,4 @@
 from asm3.dbupdate import execute
 
 execute(dbo, "INSERT INTO lksfieldtype (ID, FieldType) VALUES (?, ?)", [15, _("Number - Incrementing", dbo.locale)])
-
+#execute(dbo,"CREATE TABLE additionalincrement ( ID INTEGER NOT NULL )")

--- a/src/asm3/dbupdates/35013.py
+++ b/src/asm3/dbupdates/35013.py
@@ -1,4 +1,3 @@
 from asm3.dbupdate import execute
 
 execute(dbo, "INSERT INTO lksfieldtype (ID, FieldType) VALUES (?, ?)", [15, _("Number - Incrementing", dbo.locale)])
-#execute(dbo,"CREATE TABLE additionalincrement ( ID INTEGER NOT NULL )")

--- a/src/main.py
+++ b/src/main.py
@@ -1826,6 +1826,10 @@ class additional(JSONEndpoint):
         self.check(asm3.users.MODIFY_ADDITIONAL_FIELDS)
         for fid in o.post.integer_list("ids"):
             asm3.additional.delete_field(o.dbo, o.user, fid)
+    
+    def post_nextid(self, o):
+        self.check(asm3.users.MODIFY_ADDITIONAL_FIELDS)
+        return asm3.additional.get_next_additional_field_number(o.dbo, o.post.integer("afid"))
 
 class animal(JSONEndpoint):
     url = "animal"

--- a/src/static/js/additional.js
+++ b/src/static/js/additional.js
@@ -151,7 +151,7 @@ $(function() {
             }
             // Show searchable for correct field types
             // of text, notes, number, lookup or multi-lookup
-            if (ft == 1 || ft == 2 || ft == 3 || ft == 6 || ft == 7) {
+            if (ft == 1 || ft == 2 || ft == 3 || ft == 6 || ft == 7 || ft == 15) {
                 $("#searchablerow").fadeIn();
             }
             else {

--- a/src/static/js/additional.js
+++ b/src/static/js/additional.js
@@ -153,6 +153,12 @@ $(function() {
             // of text, notes, number, lookup or multi-lookup
             if (ft == 1 || ft == 2 || ft == 3 || ft == 6 || ft == 7 || ft == 15) {
                 $("#searchablerow").fadeIn();
+                if (ft == 15) {
+                    $("#newrecord").prop('checked', true);
+                    $("#newrecord").prop('disabled', true);
+                } else {
+                    $("#newrecord").prop('disabled', false);
+                }
             }
             else {
                 $("#searchable").prop("checked", false);

--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1654,7 +1654,8 @@ const tableform = {
         if (v.value) { d += "value=\"" + tableform._attr_value(v.value) + "\" "; }
         if (v.xattr) { d += v.xattr + " "; }
         d += "/>";
-        d += " <button id=\"button-" + v.id + "\"><span class=\"ui-button-icon ui-icon ui-icon-refresh\"></span></button>";
+        //d += " <button id=\"button-" + v.id + "\"><span class=\"ui-button-icon ui-icon ui-icon-refresh\"></span></button>";
+        if (v.xbutton) { d += " <button id=\"button-" + v.id + "\">" + v.xbutton + "</button>"; }
         if (v.xmarkup) { d += v.xmarkup; }
         return tableform._render_formfield(v, d);
     },

--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1635,6 +1635,30 @@ const tableform = {
         return tableform._render_formfield(v, d);
     },
 
+    render_number_incremented: function(v) {
+        let d = "";
+        tableform._check_id(v);
+        d += "<input type=\"text\" ";
+        d += tableform._render_class(v, "asm-textbox asm-numberbox");
+        d += tableform._render_style(v, "");
+        if (v.id) { d += "id=\"" + v.id + "\" "; }
+        if (v.name) { d += "name=\"" + v.name + "\" "; }
+        if (v.json_field) { d += "data-json=\"" + v.json_field + "\" "; }
+        if (v.post_field) { d += "data-post=\"" + v.post_field + "\" "; }
+        if (v.min) { d += "data-min=\"" + v.min + "\" " ;}
+        if (v.max) { d += "data-max=\"" + v.max + "\" " ;}
+        if (v.readonly) { d += "data-noedit=\"true\" "; }
+        if (v.validation) { d += tableform._render_validation_attr(v); }
+        if (v.tooltip) { d += "title=\"" + html.title(v.tooltip) + "\""; }
+        if (v.placeholder) { d += "placeholder=\"" + v.placeholder + "\" "; }
+        if (v.value) { d += "value=\"" + tableform._attr_value(v.value) + "\" "; }
+        if (v.xattr) { d += v.xattr + " "; }
+        d += "/>";
+        d += " <button id=\"button-" + v.id + "\"><span class=\"ui-button-icon ui-icon ui-icon-refresh\"></span></button>";
+        if (v.xmarkup) { d += v.xmarkup; }
+        return tableform._render_formfield(v, d);
+    },
+
     render_person: function(v) {
         let d = "";
         tableform._check_id(v);

--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1635,31 +1635,6 @@ const tableform = {
         return tableform._render_formfield(v, d);
     },
 
-    render_number_incremented: function(v) {
-        let d = "";
-        tableform._check_id(v);
-        d += "<input type=\"text\" ";
-        d += tableform._render_class(v, "asm-textbox asm-numberbox");
-        d += tableform._render_style(v, "");
-        if (v.id) { d += "id=\"" + v.id + "\" "; }
-        if (v.name) { d += "name=\"" + v.name + "\" "; }
-        if (v.json_field) { d += "data-json=\"" + v.json_field + "\" "; }
-        if (v.post_field) { d += "data-post=\"" + v.post_field + "\" "; }
-        if (v.min) { d += "data-min=\"" + v.min + "\" " ;}
-        if (v.max) { d += "data-max=\"" + v.max + "\" " ;}
-        if (v.readonly) { d += "data-noedit=\"true\" "; }
-        if (v.validation) { d += tableform._render_validation_attr(v); }
-        if (v.tooltip) { d += "title=\"" + html.title(v.tooltip) + "\""; }
-        if (v.placeholder) { d += "placeholder=\"" + v.placeholder + "\" "; }
-        if (v.value) { d += "value=\"" + tableform._attr_value(v.value) + "\" "; }
-        if (v.xattr) { d += v.xattr + " "; }
-        d += "/>";
-        //d += " <button id=\"button-" + v.id + "\"><span class=\"ui-button-icon ui-icon ui-icon-refresh\"></span></button>";
-        if (v.xbutton) { d += " <button id=\"button-" + v.id + "\">" + v.xbutton + "</button>"; }
-        if (v.xmarkup) { d += v.xmarkup; }
-        return tableform._render_formfield(v, d);
-    },
-
     render_person: function(v) {
         let d = "";
         tableform._check_id(v);

--- a/src/static/js/header_additional.js
+++ b/src/static/js/header_additional.js
@@ -548,7 +548,7 @@ additional = {
         else if (f.FIELDTYPE == additional.TIME) { return tableform.render_time(v); }
         else if (f.FIELDTYPE == additional.NOTES) { v.classes += " asm-textareafixed"; return tableform.render_textarea(v); }
         else if (f.FIELDTYPE == additional.NUMBER) { return tableform.render_number(v); }
-        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) { return tableform.render_number_incremented(v); }
+        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) { v.xbutton = "<span class=\"ui-button-icon ui-icon ui-icon-refresh\" onclick='console.log($(this).parent().prev().val(\"Number\"))'></span>"; return tableform.render_number(v); }
         else if (f.FIELDTYPE == additional.MONEY) { return tableform.render_currency(v); }
         else if (f.FIELDTYPE == additional.ANIMAL_LOOKUP) { return tableform.render_animal(v); }
         else if (f.FIELDTYPE == additional.PERSON_LOOKUP) { return tableform.render_person(v); }

--- a/src/static/js/header_additional.js
+++ b/src/static/js/header_additional.js
@@ -527,7 +527,7 @@ additional = {
      * classes: one or more classes to give fields - undefined="additional" 
      * usedefault: if true, outputs the default value instead of the actual value
      */
-    render_field: function(f, includeids, classes, usedefault) {
+    render_field: async function(f, includeids, classes, usedefault) {
         let v = {
             id: (includeids === undefined || includeids == true) ? "add_" + f.ID : "",
             post_field: "a." + f.MANDATORY + "." + f.ID,
@@ -548,7 +548,17 @@ additional = {
         else if (f.FIELDTYPE == additional.TIME) { return tableform.render_time(v); }
         else if (f.FIELDTYPE == additional.NOTES) { v.classes += " asm-textareafixed"; return tableform.render_textarea(v); }
         else if (f.FIELDTYPE == additional.NUMBER) { return tableform.render_number(v); }
-        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) { v.xbutton = "<span class=\"ui-button-icon ui-icon ui-icon-refresh\" onclick='console.log($(this).parent().prev().val(\"Number\"))'></span>"; return tableform.render_number(v); }
+        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) {
+            let formdata = { "mode": "nextid", "afid": v.ID };
+            let response = await common.ajax_post("additional", formdata);
+            console.log(response);
+            v.readonly = true;
+            if (!v.value) {
+                v.value = response;
+            }
+            console.log("Rendering");
+            return tableform.render_number(v);
+        }
         else if (f.FIELDTYPE == additional.MONEY) { return tableform.render_currency(v); }
         else if (f.FIELDTYPE == additional.ANIMAL_LOOKUP) { return tableform.render_animal(v); }
         else if (f.FIELDTYPE == additional.PERSON_LOOKUP) { return tableform.render_person(v); }
@@ -584,6 +594,7 @@ additional = {
             v.options = mopts.join("\n");
             return tableform.render_selectmulti(v); 
         }
+        console.log("Rendered");
     },
 
     /**

--- a/src/static/js/header_additional.js
+++ b/src/static/js/header_additional.js
@@ -548,7 +548,7 @@ additional = {
         else if (f.FIELDTYPE == additional.TIME) { return tableform.render_time(v); }
         else if (f.FIELDTYPE == additional.NOTES) { v.classes += " asm-textareafixed"; return tableform.render_textarea(v); }
         else if (f.FIELDTYPE == additional.NUMBER) { return tableform.render_number(v); }
-        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) { return tableform.render_number(v); }
+        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) { return tableform.render_number_incremented(v); }
         else if (f.FIELDTYPE == additional.MONEY) { return tableform.render_currency(v); }
         else if (f.FIELDTYPE == additional.ANIMAL_LOOKUP) { return tableform.render_animal(v); }
         else if (f.FIELDTYPE == additional.PERSON_LOOKUP) { return tableform.render_person(v); }

--- a/src/static/js/header_additional.js
+++ b/src/static/js/header_additional.js
@@ -184,6 +184,13 @@ additional = {
         $.each(fields, function(i, f) {
             if (f.NEWRECORD == 1) {
                 add.push(additional.render_field(f, includeids, classes, true));
+                if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) {
+                    let formdata = { "mode": "nextid", "afid": f.ID };
+                    common.ajax_post("additional", formdata, function(response) {
+                        $("#add_" + f.ID).val(response);
+                    });
+                    
+                }
             }
         });
         return add.join("\n");
@@ -527,7 +534,7 @@ additional = {
      * classes: one or more classes to give fields - undefined="additional" 
      * usedefault: if true, outputs the default value instead of the actual value
      */
-    render_field: async function(f, includeids, classes, usedefault) {
+    render_field: function(f, includeids, classes, usedefault) {
         let v = {
             id: (includeids === undefined || includeids == true) ? "add_" + f.ID : "",
             post_field: "a." + f.MANDATORY + "." + f.ID,
@@ -549,14 +556,7 @@ additional = {
         else if (f.FIELDTYPE == additional.NOTES) { v.classes += " asm-textareafixed"; return tableform.render_textarea(v); }
         else if (f.FIELDTYPE == additional.NUMBER) { return tableform.render_number(v); }
         else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) {
-            let formdata = { "mode": "nextid", "afid": v.ID };
-            let response = await common.ajax_post("additional", formdata);
-            console.log(response);
             v.readonly = true;
-            if (!v.value) {
-                v.value = response;
-            }
-            console.log("Rendering");
             return tableform.render_number(v);
         }
         else if (f.FIELDTYPE == additional.MONEY) { return tableform.render_currency(v); }

--- a/src/static/js/header_additional.js
+++ b/src/static/js/header_additional.js
@@ -594,7 +594,6 @@ additional = {
             v.options = mopts.join("\n");
             return tableform.render_selectmulti(v); 
         }
-        console.log("Rendered");
     },
 
     /**

--- a/src/static/js/header_additional.js
+++ b/src/static/js/header_additional.js
@@ -34,6 +34,7 @@ additional = {
     PERSON_VET: 12,
     PERSON_ADOPTIONCOORDINATOR: 13,
     TELEPHONE: 14,
+    NUMBER_INCREMENTED: 15,
 
     /**
      * Renders and lays out additional fields from data from the backend 
@@ -122,7 +123,7 @@ additional = {
                 if (f.FIELDTYPE == additional.YESNO) {
                     element.prop("checked", (fieldval && fieldval == "1"));
                 }
-                else if (f.FIELDTYPE == additional.TEXT ||  f.FIELDTYPE == additional.NUMBER) {
+                else if (f.FIELDTYPE == additional.TEXT ||  f.FIELDTYPE == additional.NUMBER ||  f.FIELDTYPE == additional.NUMBER_INCREMENTED) {
                     element.val(html.decode(fieldval));
                 }
                 else if (f.FIELDTYPE == additional.NOTES) {
@@ -283,7 +284,7 @@ additional = {
                     if (f.FIELDTYPE == additional.YESNO) {
                         row[f.FIELDNAME.toUpperCase()] = (element.is(":checked") ? "1" : "");
                     }
-                    else if (f.FIELDTYPE == additional.TEXT || f.FIELDTYPE == additional.NOTES || f.FIELDTYPE == additional.NUMBER) {
+                    else if (f.FIELDTYPE == additional.TEXT || f.FIELDTYPE == additional.NOTES || f.FIELDTYPE == additional.NUMBER || f.FIELDTYPE == additional.NUMBER_INCREMENTED) {
                         row[f.FIELDNAME.toUpperCase()] = element.val();
                     }
                     else if (f.FIELDTYPE == additional.DATE) {
@@ -350,7 +351,7 @@ additional = {
                     if (f.FIELDTYPE == additional.YESNO) {
                         return_string += "&" + fid + "=" + (element.is(":checked") ? "on" : "");
                     }
-                    else if (f.FIELDTYPE == additional.TEXT || f.FIELDTYPE == additional.DATE || f.FIELDTYPE == additional.TIME || f.FIELDTYPE == additional.NOTES || f.FIELDTYPE == additional.NUMBER) {
+                    else if (f.FIELDTYPE == additional.TEXT || f.FIELDTYPE == additional.DATE || f.FIELDTYPE == additional.TIME || f.FIELDTYPE == additional.NOTES || f.FIELDTYPE == additional.NUMBER || f.FIELDTYPE == additional.NUMBER_INCREMENTED) {
                         return_string += "&" + fid + "=" + element.val();
                     }
                     else if (f.FIELDTYPE == additional.MONEY) {
@@ -547,6 +548,7 @@ additional = {
         else if (f.FIELDTYPE == additional.TIME) { return tableform.render_time(v); }
         else if (f.FIELDTYPE == additional.NOTES) { v.classes += " asm-textareafixed"; return tableform.render_textarea(v); }
         else if (f.FIELDTYPE == additional.NUMBER) { return tableform.render_number(v); }
+        else if (f.FIELDTYPE == additional.NUMBER_INCREMENTED) { return tableform.render_number(v); }
         else if (f.FIELDTYPE == additional.MONEY) { return tableform.render_currency(v); }
         else if (f.FIELDTYPE == additional.ANIMAL_LOOKUP) { return tableform.render_animal(v); }
         else if (f.FIELDTYPE == additional.PERSON_LOOKUP) { return tableform.render_person(v); }


### PR DESCRIPTION
Lots of people want to keep their own custom auto number schemes for things. The most recent one I've seen is for giving authorisation to vets (sort of vouchers, but not quite), but it's something a lot of people ask for.

Could we implement this as part of the additional field functionality? Add a new "Incrementing Number" type.

Like receipt numbers, we'd store the next value in the config table as AdditionalNextID (where ID is the additionalfieldid). This would allow the start position to be overridden where necessary. The field would probably include a button to retrieve the next number and increment the count.