### PR TITLE
Mobile UI not extracting the error message correctly

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1075,8 +1075,11 @@ class mobile(ASMEndpoint):
 
     def post_addanimal(self, o):
         self.check(asm3.users.ADD_ANIMAL)
-        nid, dummy = asm3.animal.insert_animal_from_form(o.dbo, o.post, o.user)
-        return asm3.utils.json( asm3.animal.get_animal(o.dbo, nid) )
+        try:
+            nid, dummy = asm3.animal.insert_animal_from_form(o.dbo, o.post, o.user)
+            return asm3.utils.json( asm3.animal.get_animal(o.dbo, nid) )
+        except asm3.utils.ASMValidationError as e:
+            return e.data
 
     def post_addlog(self, o):
         self.check(asm3.users.ADD_LOG)

--- a/src/main.py
+++ b/src/main.py
@@ -1075,11 +1075,8 @@ class mobile(ASMEndpoint):
 
     def post_addanimal(self, o):
         self.check(asm3.users.ADD_ANIMAL)
-        try:
-            nid, dummy = asm3.animal.insert_animal_from_form(o.dbo, o.post, o.user)
-            return asm3.utils.json( asm3.animal.get_animal(o.dbo, nid) )
-        except asm3.utils.ASMValidationError as e:
-            return e.data
+        nid, dummy = asm3.animal.insert_animal_from_form(o.dbo, o.post, o.user)
+        return asm3.utils.json( asm3.animal.get_animal(o.dbo, nid) )
 
     def post_addlog(self, o):
         self.check(asm3.users.ADD_LOG)

--- a/src/static/js/mobile.js
+++ b/src/static/js/mobile.js
@@ -36,7 +36,7 @@ const mobile = {
                 if (errorfunc) {
                     errorfunc(textstatus, response);
                 }
-                mobile.show_error(textstatus, response);
+                mobile.show_error(textstatus, jqxhr.responseText);
             }
         });
     },

--- a/src/static/js/mobile_ui_addanimal.js
+++ b/src/static/js/mobile_ui_addanimal.js
@@ -147,12 +147,10 @@ const mobile_ui_addanimal = {
             mobile.ajax_post(
                 formdata, 
                 function(response) {
-                    if (response.responseText) {
-                        $("#addanimal-submit .spinner-border").hide();
-                    } else {
+                    $("#addanimal-submit .spinner-border").hide();
+                    if (!response.responseText) {
                         let a = jQuery.parseJSON(response);
                         controller.animals.push(a);
-                        // TODO: This needs to point to mobile_ui_animal instead
                         mobile_ui_animal.render(a);
                         mobile_ui_animal.render_shelteranimalslist();
                         $(".container").hide();

--- a/src/static/js/mobile_ui_addanimal.js
+++ b/src/static/js/mobile_ui_addanimal.js
@@ -144,21 +144,25 @@ const mobile_ui_addanimal = {
                 "internallocation": $("#internallocation").val(),
                 "unit": $("#unit").val()
             };
-            if (formdata.animalname) {
-                mobile.ajax_post(formdata, function(response) {
-                    let a = jQuery.parseJSON(response);
-                    controller.animals.push(a);
-                    // TODO: This needs to point to mobile_ui_animal instead
-                    mobile_ui_animal.render(a);
-                    mobile_ui_animal.render_shelteranimalslist();
-                    $(".container").hide();
-                    $("#content-animal").show();
+            mobile.ajax_post(
+                formdata, 
+                function(response) {
+                    if (response.responseText) {
+                        $("#addanimal-submit .spinner-border").hide();
+                    } else {
+                        let a = jQuery.parseJSON(response);
+                        controller.animals.push(a);
+                        // TODO: This needs to point to mobile_ui_animal instead
+                        mobile_ui_animal.render(a);
+                        mobile_ui_animal.render_shelteranimalslist();
+                        $(".container").hide();
+                        $("#content-animal").show();
+                    }
+                },
+                function(response) {
                     $("#addanimal-submit .spinner-border").hide();
-                });
-            } else {
-                mobile.show_error(_("Error"), _("Name cannot be blank"));
-                $("#addanimal-submit .spinner-border").hide();
-            }
+                }
+            );
         });
    
     },

--- a/src/static/js/mobile_ui_addanimal.js
+++ b/src/static/js/mobile_ui_addanimal.js
@@ -144,16 +144,21 @@ const mobile_ui_addanimal = {
                 "internallocation": $("#internallocation").val(),
                 "unit": $("#unit").val()
             };
-            mobile.ajax_post(formdata, function(response) {
-                let a = jQuery.parseJSON(response);
-                controller.animals.push(a);
-                // TODO: This needs to point to mobile_ui_animal instead
-                mobile_ui_animal.render(a);
-                mobile_ui_animal.render_shelteranimalslist();
-                $(".container").hide();
-                $("#content-animal").show();
+            if (formdata.animalname) {
+                mobile.ajax_post(formdata, function(response) {
+                    let a = jQuery.parseJSON(response);
+                    controller.animals.push(a);
+                    // TODO: This needs to point to mobile_ui_animal instead
+                    mobile_ui_animal.render(a);
+                    mobile_ui_animal.render_shelteranimalslist();
+                    $(".container").hide();
+                    $("#content-animal").show();
+                    $("#addanimal-submit .spinner-border").hide();
+                });
+            } else {
+                mobile.show_error(_("Error"), _("Name cannot be blank"));
                 $("#addanimal-submit .spinner-border").hide();
-            });
+            }
         });
    
     },


### PR DESCRIPTION
If manual codes is turned on, and you add an animal through the mobile UI without supplying a code, the validation error is thrown and passed to the client, but the message is not parsed correctly and all that is shown to the user is a dialog with the word "error".