### PR TITLE
Ansible: playbook updates for v50 deployment

### DIFF
--- a/scripts/ansible/asm_install.yml
+++ b/scripts/ansible/asm_install.yml
@@ -3,6 +3,9 @@
   become: "yes"
   roles:
     - "City-of-Bloomington.apache"
+  vars:
+    archive_name: "asm3-{{ asm_version }}"
+    archive_path: "archives/asm3-{{ asm_version }}.tar.gz"
   tasks:
     - name: "Mysql setup"
       include_tasks: "tasks/mysql.yml"
@@ -20,40 +23,28 @@
         packages:
           - "libapache2-mod-wsgi-py3"
           - "make"
-          - "python3-pil"
-          - "python3-webpy"
           - "imagemagick"
           - "wkhtmltopdf"
-          - "python3-requests"
           - "memcached"
-          - "python3-memcache"
           - "curl"
+          - "python3-lxml"
+          - "python3-memcache"
+          - "python3-pil"
+          - "python3-requests"
+          - "python3-webpy"
 
     - name: "Activate Apache WSGI Module"
       apache2_module:
         name: "wsgi"
 
-    - name: "Extract release"
-      unarchive:
-        src: "{{ asm_archive.path }}"
-        dest: "/usr/local/src"
-      register: "release"
-
-    - name: "Remove old release"
-      file:
-        path: "{{ asm_path }}"
-        state: "absent"
-      when: "release.changed"
-
     - name: "Create ASM directories"
-      file:
+      ansible.builtin.file:
         path: "{{ item }}"
         state: "directory"
         owner: "www-data"
         group: "staff"
         mode: "u=rwx,g=rwxs,o=rx"
       with_items:
-        - "{{ asm_path }}"
         - "{{ asm_data }}"
         - "{{ asm_data }}/cache"
         - "{{ asm_data }}/media"
@@ -61,9 +52,25 @@
         - "/srv/backups/asm"
         - "/var/log/cron"
 
-    - name: "Install release"
-      command: "rsync -rlv /usr/local/src/{{ asm_archive.name }}/ {{ asm_path }}/"
-      when: "release.changed"
+    - name: "Extract release"
+      ansible.builtin.unarchive:
+        src:  "{{ archive_path }}"
+        dest: "{{ asm_path | dirname }}"
+        owner: 'www-data'
+        group: 'staff'
+
+    - name: "Symlink Release"
+      ansible.builtin.file:
+        path:  "{{ asm_path }}"
+        src:   "{{ asm_path | dirname }}/{{ archive_name }}"
+        state: 'link'
+        owner: 'www-data'
+        group: 'staff'
+
+    - name: "Create Version File"
+      ansible.builtin.template:
+        src: "__version__.py"
+        dest: "{{ asm_path }}/src/asm3/__version__.py"
 
     - name: "Update apache configuration"
       template:

--- a/scripts/ansible/inventory_example/group_vars/asm/public.yml
+++ b/scripts/ansible/inventory_example/group_vars/asm/public.yml
@@ -1,9 +1,5 @@
 ---
 asm_version: "46"
-asm_archive:
-  name: "asm3-{{ asm_version }}"
-  ext: ".tar.gz"
-  path: "archives/asm3-{{ asm_version }}.tar.gz"
 
 asm_path: "/srv/sites/asm"
 asm_data: "/srv/data/asm"

--- a/scripts/ansible/templates/__version__.py
+++ b/scripts/ansible/templates/__version__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+VERSION = "{{ asm_version}} [{{ now(fmt='%c') }}]"
+BUILD = "{{ now(fmt='%m%d%H%M%S') }}"

--- a/scripts/ansible/templates/asm3.wsgi
+++ b/scripts/ansible/templates/asm3.wsgi
@@ -1,5 +1,5 @@
 import os, sys
 sys.path.insert(0, "{{ asm_path }}/src")
 os.environ["ASM3_CONF"] = "{{ asm_data }}/asm3.conf"
-import code
-application = code.application
+import main
+application = main.application


### PR DESCRIPTION
* code.py is now main.py
* Ansible now generates a __version__ file, since it's not not included in the src archive

This also improves extracting from the tarball.  We no longer extract to /usr/local/src and then rsync.  Instead, we extract to /srv/sites and then symlink to the new directory.

Updates #1845 