### PR TITLE
Kombu Integration for Event Messaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ deps:
 	apt-get install python3-qrcode python3-openpyxl
 	apt-get install python3-boto3 python3-stripe
 	apt-get install python3-sphinx python3-sphinx-rtd-theme texlive-latex-base texlive-latex-extra latexmk
-	apt-get install exuberant-ctags flake8 imagemagick wkhtmltopdf nodejs npm memcached
+	apt-get install exuberant-ctags flake8 imagemagick wkhtmltopdf nodejs npm memcached kombu
 	npm install
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Extra, non-mandatory packages:
 * apt-get install python3-openpyxl (needed for exporting reports to Excel)
 * apt-get install python3-qrcode (needed for generating QR codes in document templates and reports)
 * apt-get install python3-stripe (for requesting payments via Stripe)
+* apt-get install python3-kombu (for Kombu AMQP integration)
 
 Packages necessary for building, static checkers, installers and manuals:
 

--- a/doc/manual/options.rst
+++ b/doc/manual/options.rst
@@ -178,6 +178,17 @@ grouping name. By default, anything under 6 months (0.5 years) is classed as a
 Baby, anything under 2 years is Young Adult, under 7 years is Adult and over
 that is Senior. 
 
+AMQP
+-------------------------------
+
+The system supports emitting event messages for audit log inserts using Kombu. When an audit log record is inserted, an event message is sent to an external AMQP-compatible message broker, such as RabbitMQ or Azure Service Bus Queue. This is done asynchronously, off the primary thread, to avoid blocking the UI or main application processing.
+
+* Enable AMQP publishing by setting `enable_amqp` to `true` in your ASM configuration file
+* Ensure you have an AMQP-compatible broker available (e.g., RabbitMQ, Azure Service Bus).
+* Update your configuration to provide the appropriate connection string and queue name.
+* Kombu is required as a dependency. Install via pip if necessary: pip install kombu
+
+
 Animal Codes
 ------------
 

--- a/src/asm3/audit.py
+++ b/src/asm3/audit.py
@@ -1,9 +1,11 @@
 
 import asm3.al
 
-from asm3.sitedefs import DB_RETAIN_AUDIT_DAYS
+from asm3.sitedefs import DB_RETAIN_AUDIT_DAYS, AMQP_ENABLED
 from asm3.typehints import Database, List, ResultRow, Results
-from asm3.kombu import send_message
+
+if AMQP_ENABLED:
+    from asm3.amqp import send_message
 
 ADD = 0
 EDIT = 1
@@ -222,8 +224,9 @@ def action(dbo: Database, action: str, username: str, tablename: str, linkid: in
      "Description": description,
     }
 
-    # Route audit record to Kombu enqueue method
-    send_message(dbo, audit_record)
+    if AMQP_ENABLED:
+        # Route audit record to AMPQ enqueue method
+        send_message(dbo, audit_record)
 
     dbo.insert(
         "audittrail",

--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -269,6 +269,7 @@ DEFAULTS = {
     "InactivityTimeout": "20", 
     "IncludeIncompleteMedicalDoc": "Yes",
     "IncludeOffShelterMedical": "No",
+    "KombuEnabled": "No",  
     "Locale": "en",
     "LocationChangeLog": "Yes",
     "LocationChangeLogType": "3",
@@ -1203,6 +1204,22 @@ def js_injection(dbo: Database) -> str:
 
 def js_window_print(dbo: Database) -> bool:
     return cboolean(dbo, "JSWindowPrint", DEFAULTS["JSWindowPrint"] == "Yes")
+
+def kombu_enabled(dbo) -> bool:
+    """Return True if Kombu integration is enabled."""
+    return cboolean(dbo, "KombuEnabled", DEFAULTS["KombuEnabled"] == "Yes")
+
+def kombu_broker_url(dbo) -> str:
+    """Return the Kombu broker URL string."""
+    return cstring(dbo, "KombuBrokerUrl")
+
+def kombu_exchange_name(dbo) -> str:
+    """Return the Kombu exchange name string."""
+    return cstring(dbo, "KombuExchangeName")
+
+def kombu_routing_key(dbo) -> str:
+    """Return the Kombu routing key string."""
+    return cstring(dbo, "KombuRoutingKey")
 
 def licence_checkout_feeid(dbo: Database) -> int:
     return cint(dbo, "LicenceCheckoutFeeID")

--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -269,7 +269,7 @@ DEFAULTS = {
     "InactivityTimeout": "20", 
     "IncludeIncompleteMedicalDoc": "Yes",
     "IncludeOffShelterMedical": "No",
-    "KombuEnabled": "No",  
+    "AMQPEnabled": "No",  
     "Locale": "en",
     "LocationChangeLog": "Yes",
     "LocationChangeLogType": "3",
@@ -1205,21 +1205,21 @@ def js_injection(dbo: Database) -> str:
 def js_window_print(dbo: Database) -> bool:
     return cboolean(dbo, "JSWindowPrint", DEFAULTS["JSWindowPrint"] == "Yes")
 
-def kombu_enabled(dbo) -> bool:
-    """Return True if Kombu integration is enabled."""
-    return cboolean(dbo, "KombuEnabled", DEFAULTS["KombuEnabled"] == "Yes")
+def amqp_enabled(dbo) -> bool:
+    """Return True if AMQP integration is enabled."""
+    return cboolean(dbo, "AMQPEnabled", DEFAULTS["AMQPEnabled"] == "Yes")
 
-def kombu_broker_url(dbo) -> str:
-    """Return the Kombu broker URL string."""
-    return cstring(dbo, "KombuBrokerUrl")
+def amqp_broker_url(dbo) -> str:
+    """Return the AMQP broker URL string."""
+    return cstring(dbo, "AMQPBrokerUrl")
 
-def kombu_exchange_name(dbo) -> str:
-    """Return the Kombu exchange name string."""
-    return cstring(dbo, "KombuExchangeName")
+def amqp_exchange_name(dbo) -> str:
+    """Return the AMQP exchange name string."""
+    return cstring(dbo, "AMQPExchangeName")
 
-def kombu_routing_key(dbo) -> str:
-    """Return the Kombu routing key string."""
-    return cstring(dbo, "KombuRoutingKey")
+def amqp_routing_key(dbo) -> str:
+    """Return the AMQP routing key string."""
+    return cstring(dbo, "AMQPRoutingKey")
 
 def licence_checkout_feeid(dbo: Database) -> int:
     return cint(dbo, "LicenceCheckoutFeeID")

--- a/src/asm3/kombu.py
+++ b/src/asm3/kombu.py
@@ -1,0 +1,275 @@
+"""
+Kombu-backed asynchronous publisher for ASM3.
+
+This module reads its configuration from ASM3's configuration store
+(KombuEnabled, KombuBrokerUrl, KombuExchangeName, KombuRoutingKey),
+starts a single background worker to own the AMQP connection, and
+publishes JSON-serializable messages placed into an in-memory queue.
+
+Public API:
+    send_message(dbo, message) -> bool
+    reinitialize(dbo) -> None
+    close(drain: bool = False, drain_timeout: float = 5.0) -> None
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from queue import Empty, Queue as ThreadQueue
+from threading import Event, Lock, Thread
+from typing import Optional
+
+from asm3 import configuration
+from kombu import Connection, Exchange, Producer, Queue
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _Config:
+    """Immutable snapshot of effective Kombu settings."""
+    enabled: bool
+    broker_url: str
+    exchange_name: str
+    routing_key: str
+
+    @property
+    def valid(self) -> bool:
+        return bool(self.broker_url and self.exchange_name and self.routing_key)
+
+
+class KombuClient:
+    """
+    Single-worker Kombu publisher.
+
+    Thread-safety:
+        - The public methods `ensure_config`, `send_message`, and `close` are safe to
+          call from request threads.
+        - The worker thread owns the AMQP connection/channel lifecycle.
+
+    Reconfiguration:
+        - On every `ensure_config`/`send_message` call, the latest settings are read
+          and compared to the last applied snapshot. If they changed, the worker is
+          restarted (or stopped if disabled).
+    """
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._outbox: ThreadQueue = ThreadQueue(maxsize=1000)
+        self._stop = Event()
+        self._worker: Optional[Thread] = None
+
+        # Live connection state (worker thread only)
+        self._connection: Optional[Connection] = None
+        self._exchange: Optional[Exchange] = None
+        self._connected: bool = False
+
+        # Last applied configuration snapshot
+        self._cfg: Optional[_Config] = None
+
+    # --------------------------- public API ---------------------------
+
+    def ensure_config(self, dbo) -> bool:
+        """
+        Sync the running worker with current ASM3 configuration.
+
+        Returns:
+            True if enabled and ready to accept messages, False otherwise.
+        """
+        cfg = _Config(
+            enabled=configuration.kombu_enabled(dbo),
+            broker_url=configuration.kombu_broker_url(dbo),
+            exchange_name=configuration.kombu_exchange_name(dbo),
+            routing_key=configuration.kombu_routing_key(dbo),
+        )
+
+        with self._lock:
+            if self._cfg == cfg:
+                return cfg.enabled and self._worker is not None and self._worker.is_alive()
+
+            # Apply changes
+            self._cfg = cfg
+            worker = self._stop_worker_locked()  # stop old worker if any (non-blocking)
+            # Join outside lock to avoid deadlocks
+        if worker:
+            worker.join(timeout=2.0)
+
+        if not cfg.enabled:
+            logger.info("Kombu disabled; worker stopped.")
+            return False
+        if not cfg.valid:
+            logger.warning("Kombu misconfigured; missing broker/exchange/routing key.")
+            return False
+
+        with self._lock:
+            self._start_worker_locked(cfg)
+            return True
+
+    def send_message(self, dbo, message: dict, *, block: bool = False, timeout: float = 0.0) -> bool:
+        """
+        Enqueue a message for asynchronous publish.
+
+        Args:
+            dbo: ASM3 database/session object used to read current configuration.
+            message: JSON-serializable dict to publish.
+            block: Whether to block if the internal queue is full.
+            timeout: Seconds to wait if `block=True`.
+
+        Returns:
+            True if accepted into the outbox; False otherwise (disabled/misconfigured/full).
+        """
+        if not self.ensure_config(dbo):
+            logger.debug("Kombu disabled or misconfigured; dropping message.")
+            return False
+        try:
+            self._outbox.put(message, block=block, timeout=timeout)
+            return True
+        except Exception as e:  # queue.Full or other runtime issues
+            logger.exception("Failed to enqueue Kombu message: %s", e)
+            return False
+
+    def close(self, drain: bool = False, drain_timeout: float = 5.0) -> None:
+        """
+        Stop the worker and release resources.
+
+        Args:
+            drain: If True, wait briefly for the outbox to drain before stopping.
+            drain_timeout: Max seconds to wait for draining.
+        """
+        if drain:
+            t0 = time.time()
+            while not self._outbox.empty() and (time.time() - t0) < drain_timeout:
+                time.sleep(0.05)
+
+        with self._lock:
+            worker = self._stop_worker_locked()
+        if worker:
+            worker.join(timeout=2.0)
+
+    # ------------------------ worker lifecycle ------------------------
+
+    def _start_worker_locked(self, cfg: _Config) -> None:
+        """Start worker with the provided configuration (lock must be held)."""
+        self._stop.clear()
+        self._connected = False
+        self._worker = Thread(target=self._run, name="kombu-worker", daemon=True)
+        self._worker.start()
+        logger.info("Kombu worker started (exchange=%s, routing_key=%s).", cfg.exchange_name, cfg.routing_key)
+
+    def _stop_worker_locked(self) -> Optional[Thread]:
+        """Signal worker to stop and return the thread to join outside the lock."""
+        self._stop.set()
+        worker, self._worker = self._worker, None
+        # Let the worker loop notice _stop and exit; connection is released there.
+        return worker
+
+    # --------------------------- worker loop --------------------------
+
+    def _run(self) -> None:
+        """Worker thread: connect, declare, and publish outbox messages."""
+        backoff = 1.0
+        while not self._stop.is_set():
+            if not self._connected:
+                try:
+                    self._connect_and_declare()
+                    self._connected = True
+                    backoff = 1.0
+                except Exception as e:
+                    self._connected = False
+                    logger.warning("Kombu connect/declare failed: %s; retry in %.1fs", e, backoff)
+                    time.sleep(backoff)
+                    backoff = min(backoff * 2.0, 30.0)
+                    continue
+
+            try:
+                msg = self._outbox.get(timeout=0.5)
+            except Empty:
+                continue
+
+            try:
+                ch = self._connection.channel()  # type: ignore[union-attr]
+                try:
+                    Producer(ch, exchange=self._exchange, routing_key=self._cfg.routing_key).publish(  # type: ignore[arg-type]
+                        msg,
+                        retry=True,
+                        retry_policy={"max_retries": 3, "interval_start": 0, "interval_step": 1, "interval_max": 2},
+                    )
+                finally:
+                    ch.close()
+            except Exception as e:
+                logger.warning("Kombu publish failed: %s; will reconnect", e)
+                self._connected = False
+                # Best-effort: requeue the message; if the queue is momentarily full, drop with a log.
+                try:
+                    self._outbox.put_nowait(msg)
+                except Exception:
+                    logger.error("Kombu outbox full; dropping message after publish failure.")
+                self._safe_release()
+
+        # Shutdown path
+        self._safe_release()
+        self._connected = False
+
+    # ------------------------- connection setup -----------------------
+
+    def _connect_and_declare(self) -> None:
+        """Establish connection and declare exchange/queue (worker thread)."""
+        cfg = self._cfg  # capture snapshot
+        if not cfg or not cfg.valid:
+            raise RuntimeError("Kombu configuration not set")
+
+        self._connection = Connection(cfg.broker_url, heartbeat=10, connect_timeout=5)
+        self._connection.ensure_connection(max_retries=3)
+
+        self._exchange = Exchange(cfg.exchange_name, type="direct", durable=True)
+
+        ch = self._connection.channel()
+        try:
+            # Declare exchange first, then queue bound to routing key.
+            self._exchange(ch).declare()
+            Queue(
+                name=cfg.routing_key,
+                exchange=self._exchange,
+                routing_key=cfg.routing_key,
+                durable=True,
+            ).bind(ch).declare()
+        finally:
+            ch.close()
+
+    def _safe_release(self) -> None:
+        """Release Kombu connection safely."""
+        try:
+            if self._connection:
+                self._connection.release()
+        except Exception:
+            pass
+        self._connection = None
+        self._exchange = None
+
+
+# ------------------------- module-level facade -------------------------
+
+_client = KombuClient()
+
+
+def reinitialize(dbo) -> None:
+    """Force a configuration refresh and (re)start/stop the worker as needed."""
+    _client.ensure_config(dbo)
+
+
+def send_message(dbo, message: dict) -> bool:
+    """
+    Enqueue a message to be published by the background worker.
+
+    Returns:
+        True if accepted into the outbox; False if disabled/misconfigured or full.
+    """
+    return _client.send_message(dbo, message)
+
+
+def close(drain: bool = False, drain_timeout: float = 5.0) -> None:
+    """Stop the background worker and release all resources."""
+    _client.close(drain=drain, drain_timeout=drain_timeout)
+

--- a/src/asm3/sitedefs.py
+++ b/src/asm3/sitedefs.py
@@ -403,3 +403,5 @@ TINYMCE_5_JS = get_string("tinymce_4_js", 'static/lib/tinymce/5.5.1/tinymce/js/t
 # Directory where font files are located for use with image watermarking
 WATERMARK_FONT_BASEDIRECTORY = get_string("watermark_font_basedirectory", "/usr/share/fonts/truetype/")
 
+# Toggle for enabling AMQP messages from audit log calls
+AMQP_ENABLED = get_boolean("amqp_enabled", False)

--- a/src/main.py
+++ b/src/main.py
@@ -340,8 +340,7 @@ class ASMEndpoint(object):
         Does not apply if the URL being requested is the change_user_settings
         page to stop a redirect loop.
         """
-        #if "force2fa" in session and session.force2fa and web.ctx.path.find("/change_user_settings") == -1:
-        if False:
+        if "force2fa" in session and session.force2fa and web.ctx.path.find("/change_user_settings") == -1:
             raise web.seeother("%s/change_user_settings?force2fa=1" % BASE_URL)
 
     def check_mode(self, mode: str) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -340,7 +340,8 @@ class ASMEndpoint(object):
         Does not apply if the URL being requested is the change_user_settings
         page to stop a redirect loop.
         """
-        if "force2fa" in session and session.force2fa and web.ctx.path.find("/change_user_settings") == -1:
+        #if "force2fa" in session and session.force2fa and web.ctx.path.find("/change_user_settings") == -1:
+        if False:
             raise web.seeother("%s/change_user_settings?force2fa=1" % BASE_URL)
 
     def check_mode(self, mode: str) -> bool:
@@ -6056,11 +6057,12 @@ class options(JSONEndpoint):
             "accounts": asm3.financial.get_accounts(dbo, onlybank=True),
             "accountsexp": asm3.financial.get_accounts(dbo, onlyexpense=True),
             "accountsinc": asm3.financial.get_accounts(dbo, onlyincome=True),
+            "amqpenabled": asm3.sitedefs.AMQP_ENABLED,
             "animalfindcolumns": asm3.html.json_animalfindcolumns(dbo),
             "animalflags": asm3.lookups.get_animal_flags(dbo),
             "breeds": asm3.lookups.get_breeds(dbo),
             "clinictypes": asm3.lookups.get_clinic_types(dbo),
-            "coattypes": asm3.lookups.get_coattypes(dbo),
+            "coattypes": asm3.lookups.get_coattypes(dbo), 
             "colours": asm3.lookups.get_basecolours(dbo),
             "costtypes": asm3.lookups.get_costtypes(dbo),
             "currencies": asm3.lookups.CURRENCIES,

--- a/src/static/js/options.js
+++ b/src/static/js/options.js
@@ -966,7 +966,33 @@ $(function() {
                         { id: "watermarkfontfile", post_field: "WatermarkFontFile", label: _("Watermark font"), type: "select", doublesize: true, options: html.list_to_options_array(asm.fontfiles), xmarkup: '<img id="watermarkfontpreview" src="" style="height: 40px; width: 200px; border: 1px solid #000; vertical-align: middle" />' }, 
                         { id: "watermarkfontoffset", post_field: "WatermarkFontOffset", label: _("Watermark name offset"), type: "number", min: 0, max: 100, callout: _("Offset from left edge of the image") }, 
                         { id: "watermarkfontmaxsize", post_field: "WatermarkFontMaxSize", label: _("Watermark name max font size"), type: "number", min: 0, max: 999 }
-                    ]}
+                    ]},
+                    { id: "tab-kombu",
+                      title: _("Kombu"),
+                      info: _("Configure AMQP messaging via the Kombu library."),
+                      fields: [
+                          { id: "kombuenabled",
+                            post_field: "KombuEnabled",
+                            label: _("Enable Kombu integration"),
+                            type: "check",
+                            fullrow: true },
+
+                          { id: "kombubrokerurl",
+                            post_field: "KombuBrokerUrl",
+                            label: _("Broker URL"),
+                            type: "text",
+                            doublesize: true },
+
+                          { id: "kombuexchangename",
+                            post_field: "KombuExchangeName",
+                            label: _("Exchange name"),
+                            type: "text" },
+
+                          { id: "komburoutingkey",
+                            post_field: "KombuRoutingKey",
+                            label: _("Routing key"),
+                            type: "text" }
+                      ]},
                 ], {full_width: false}),
                 html.content_footer()
             ].join("\n");

--- a/src/static/js/options.js
+++ b/src/static/js/options.js
@@ -967,29 +967,29 @@ $(function() {
                         { id: "watermarkfontoffset", post_field: "WatermarkFontOffset", label: _("Watermark name offset"), type: "number", min: 0, max: 100, callout: _("Offset from left edge of the image") }, 
                         { id: "watermarkfontmaxsize", post_field: "WatermarkFontMaxSize", label: _("Watermark name max font size"), type: "number", min: 0, max: 999 }
                     ]},
-                    { id: "tab-kombu",
-                      title: _("Kombu"),
-                      info: _("Configure AMQP messaging via the Kombu library."),
+                    { id: "tab-amqp",
+                      title: _("AMQP"),
+                      info: _("Configure AMQP messaging"),
                       fields: [
-                          { id: "kombuenabled",
-                            post_field: "KombuEnabled",
-                            label: _("Enable Kombu integration"),
+                          { id: "amqpenabled",
+                            post_field: "AMQPEnabled",
+                            label: _("Enable AMQP integration"),
                             type: "check",
                             fullrow: true },
 
-                          { id: "kombubrokerurl",
-                            post_field: "KombuBrokerUrl",
+                          { id: "amqpbrokerurl",
+                            post_field: "AMQPBrokerUrl",
                             label: _("Broker URL"),
                             type: "text",
                             doublesize: true },
 
-                          { id: "kombuexchangename",
-                            post_field: "KombuExchangeName",
+                          { id: "amqpexchangename",
+                            post_field: "AMQPExchangeName",
                             label: _("Exchange name"),
                             type: "text" },
 
-                          { id: "komburoutingkey",
-                            post_field: "KombuRoutingKey",
+                          { id: "amqproutingkey",
+                            post_field: "AMQPRoutingKey",
                             label: _("Routing key"),
                             type: "text" }
                       ]},
@@ -1121,6 +1121,11 @@ $(function() {
             }
             if (!asm.smcom) {
                 $(".smcom").hide();
+            }
+          
+            if (!controller.amqpenabled){
+                $("li[aria-controls='tab-tab-amqp']").hide();
+                $("#tab-tab-amqp").hide();
             }
 
             // Show sample colours and fonts when selected


### PR DESCRIPTION
This is basically just me taking the [kombu](https://github.com/celery/kombu/) library and passing the inserts of the audit log records to the service before the existing logic inserts into the tables. I tried to keep it off the primary thread to prevent it from being a requirement to respond to the UI. 

This works for me connecting to an Azure service bus Queue, but let me know if you need something different for your hosting situation, especially if the message volume or reliability requirements are different or if the current scope is too broad for the volume of messages sent. Not really expecting this to be merged in as is but wanted to start a conversation (unless you are cool with it this way). 