### PR TITLE
Mail merge: add custom log

### DIFF
--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -37,7 +37,7 @@ TABLES = ( "accounts", "accountsrole", "accountstrx", "additional", "additionalf
     "lksex", "lksfieldlink", "lksfieldtype", "lksize", "lktaxrate", "lksloglink", "lksmedialink", "lksmediatype", "lksmedicaltype", 
     "lksmovementtype", "lksoutcome", "lksposneg", "lksrotatype", "lksunittype", "lksyesno", "lksynun", "lksynunk", 
     "lkstransportstatus", "lkurgency", "lkwaitinglistremoval", "lkworktype", 
-    "log", "logtype", "media", "medicalprofile", "messages", "onlineform", 
+    "log", "logmulti", "logtype", "media", "medicalprofile", "messages", "onlineform", 
     "onlineformfield", "onlineformincoming", "owner", "ownercitation", "ownerdonation", "ownerinvestigation", 
     "ownerlicence", "ownerlookingfor", "ownerrole", "ownerrota", "ownertraploan", "ownervoucher", "pickuplocation", "product", "publishlog", 
     "reservationstatus", "role", "site", "species", "stocklevel", "stocklocation", "stockusage", "stockusagetype", 
@@ -72,7 +72,7 @@ TABLES_DATA = ( "accountsrole", "accountstrx", "additional", "adoption",
     "animalfound", "animallitter", "animallost", "animalmedical", "animalmedicaltreatment", "animalname",
     "animaltest", "animaltransport", "animalvaccination", "animalwaitinglist", "audittrail", 
     "clinicappointment", "clinicinvoiceitem", "deletion", "diary", "event", "eventanimal", 
-    "log", "ownerlookingfor", "publishlog", "media", "messages", "owner", "ownercitation", 
+    "log", "logmulti", "ownerlookingfor", "publishlog", "media", "messages", "owner", "ownercitation", 
     "ownerdonation", "ownerinvestigation", "ownerlicence", "ownerrole", "ownerrota", "ownertraploan", "ownervoucher", 
     "stocklevel", "stockusage" )
 
@@ -1243,6 +1243,16 @@ def sql_structure(dbo: Database) -> str:
         fid(),
         fint("LogTypeID"),
         fint("LinkID"),
+        fint("LinkType"),
+        fdate("Date"),
+        flongstr("Comments") ))
+    sql += index("log_LogTypeID", "log", "LogTypeID")
+    sql += index("log_LinkID", "log", "LinkID")
+
+    sql += table("logmulti", (
+        fid(),
+        fint("LogTypeID"),
+        flongstr("LinkIDs"),
         fint("LinkType"),
         fdate("Date"),
         flongstr("Comments") ))

--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -1256,8 +1256,8 @@ def sql_structure(dbo: Database) -> str:
         fint("LinkType"),
         fdate("Date"),
         flongstr("Comments") ))
-    sql += index("log_LogTypeID", "log", "LogTypeID")
-    sql += index("log_LinkID", "log", "LinkID")
+    sql += index("logmulti_LogTypeID", "logmulti", "LogTypeID")
+    sql += index("logmulti_LinkType", "logmulti", "LinkType")
 
     sql += table("logtype", (
         fid(),

--- a/src/asm3/dbupdates/35013.py
+++ b/src/asm3/dbupdates/35013.py
@@ -1,0 +1,10 @@
+from asm3.dbupdate import execute
+
+fields = ",".join([
+    dbo.ddl_add_table_column("ID", dbo.type_integer, False, pk=True),
+    dbo.ddl_add_table_column("LogTypeID", dbo.type_integer, False),
+    dbo.ddl_add_table_column("LinkTypeID", dbo.type_integer, False),
+    dbo.ddl_add_table_column("LinkIDs", dbo.type_longtext, False),
+    dbo.ddl_add_table_column("LogMessage", dbo.type_longtext, False)
+])
+execute(dbo, dbo.ddl_add_table("logmulti", fields) )

--- a/src/asm3/dbupdates/35100.py
+++ b/src/asm3/dbupdates/35100.py
@@ -2,12 +2,18 @@ from asm3.dbupdate import execute, add_index
 
 fields = ",".join([
     dbo.ddl_add_table_column("ID", dbo.type_integer, False, pk=True),
+    dbo.ddl_add_table_column("Date", dbo.type_datetime, False),
     dbo.ddl_add_table_column("LogTypeID", dbo.type_integer, False),
-    dbo.ddl_add_table_column("LinkTypeID", dbo.type_integer, False),
+    dbo.ddl_add_table_column("LinkType", dbo.type_integer, False),
     dbo.ddl_add_table_column("LinkIDs", dbo.type_longtext, False),
-    dbo.ddl_add_table_column("LogMessage", dbo.type_longtext, False)
+    dbo.ddl_add_table_column("Comments", dbo.type_longtext, False),
+    dbo.ddl_add_table_column("RecordVersion", dbo.type_integer, True),
+    dbo.ddl_add_table_column("CreatedBy", dbo.type_shorttext, False),
+    dbo.ddl_add_table_column("CreatedDate", dbo.type_datetime, False),
+    dbo.ddl_add_table_column("LastChangedBy", dbo.type_shorttext, False),
+    dbo.ddl_add_table_column("LastChangedDate", dbo.type_datetime, False)
 ])
 execute(dbo, dbo.ddl_add_table("logmulti", fields) )
 
 add_index(dbo, "logmulti_LogTypeID", "logmulti", "LogTypeID")
-add_index(dbo, "logmulti_LinkTypeID", "logmulti", "LinkTypeID")
+add_index(dbo, "logmulti_LinkType", "logmulti", "LinkType")

--- a/src/asm3/dbupdates/35100.py
+++ b/src/asm3/dbupdates/35100.py
@@ -1,4 +1,4 @@
-from asm3.dbupdate import execute
+from asm3.dbupdate import execute, add_index
 
 fields = ",".join([
     dbo.ddl_add_table_column("ID", dbo.type_integer, False, pk=True),
@@ -8,3 +8,6 @@ fields = ",".join([
     dbo.ddl_add_table_column("LogMessage", dbo.type_longtext, False)
 ])
 execute(dbo, dbo.ddl_add_table("logmulti", fields) )
+
+add_index(dbo, "logmulti_LogTypeID", "logmulti", "LogTypeID")
+add_index(dbo, "logmulti_LinkTypeID", "logmulti", "LinkTypeID")

--- a/src/asm3/log.py
+++ b/src/asm3/log.py
@@ -37,6 +37,20 @@ def add_log_email(dbo: Database, username: str, linktype: int, linkid: int, logt
     return add_log(dbo, username, linktype, linkid, logtypeid,
         "[%s] %s ::\n%s" % ( to, subject, body ))
 
+def add_logmulti(dbo: Database, username: str, linktype: int, linkids: list, logtypeid: int, logtext: str, logdatetime: datetime = None) -> int:
+    """
+    Adds a log entry. If logdatetime is blank, the date/time now is used.
+    """
+    linkidsstring = ",".join(linkids)
+    if logdatetime is None: logdatetime = dbo.now()
+    return dbo.insert("logmulti", {
+        "LogTypeID":        logtypeid,
+        "LinkIDs":          linkidsstring,
+        "LinkType":         linktype,
+        "Date":             logdatetime,
+        "Comments":         logtext
+    }, username)
+
 def get_log_find_simple(dbo: Database, q: str, limit: int = 0) -> Results:
     """
     Searches log notes for the term q

--- a/src/asm3/log.py
+++ b/src/asm3/log.py
@@ -39,9 +39,9 @@ def add_log_email(dbo: Database, username: str, linktype: int, linkid: int, logt
 
 def add_logmulti(dbo: Database, username: str, linktype: int, linkids: list, logtypeid: int, logtext: str, logdatetime: datetime = None) -> int:
     """
-    Adds a log entry. If logdatetime is blank, the date/time now is used.
+    Adds a logmulti entry. If logdatetime is blank, the date/time now is used.
     """
-    linkidsstring = ",".join(linkids)
+    linkidsstring = ",".join([str(linkid) for linkid in linkids] )
     if logdatetime is None: logdatetime = dbo.now()
     return dbo.insert("logmulti", {
         "LogTypeID":        logtypeid,

--- a/src/asm3/utils.py
+++ b/src/asm3/utils.py
@@ -2179,9 +2179,9 @@ def send_bulk_email(dbo: Database, replyadd: str, subject: str, body: str, rows:
             send_email(dbo, replyadd, toadd, "", "", ssubject, sbody, contenttype, exceptions=False, bulk=True)
             if createlog:
                 if "OWNERID" in r:
-                    linkids.append(str(r.OWNERID))
+                    linkids.append(r.OWNERID)
                 elif "ID" in r:
-                    linkids.append(str(r.ID))
+                    linkids.append(r.ID)
             if "EMAILADDRESS2" in r: 
                 toadd = r.EMAILADDRESS2
                 if toadd is None or toadd.strip() == "": continue

--- a/src/main.py
+++ b/src/main.py
@@ -4868,7 +4868,8 @@ class mailmerge(JSONEndpoint):
             "numrows": len(rows),
             "hasemail": "EMAILADDRESS" in fields,
             "hasaddress": "OWNERNAME" in fields and "OWNERADDRESS" in fields and "OWNERTOWN" in fields and "OWNERCOUNTY" in fields and "OWNERPOSTCODE" in fields,
-            "templates": asm3.template.get_document_templates(dbo, "mailmerge")
+            "templates": asm3.template.get_document_templates(dbo, "mailmerge"),
+            "logtypes": asm3.lookups.get_log_types(dbo)
         }
    
     def post_email(self, o):

--- a/src/main.py
+++ b/src/main.py
@@ -4890,7 +4890,7 @@ class mailmerge(JSONEndpoint):
             emails = self.recipients(rows)
             asm3.audit.email(dbo, o.user, fromadd, ",".join(emails), "", "", subject, body)
 
-        asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"), createlog=post.boolean("logemail"), logtypeid=post.integer("logtype"), logmessage=post["logmessage"], username="test")
+        asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"), createlog=post.boolean("logemail"), logtypeid=post.integer("logtype"), logmessage=post["logmessage"], username=o.user)
 
     def post_document(self, o):
         dbo = o.dbo

--- a/src/main.py
+++ b/src/main.py
@@ -4889,6 +4889,9 @@ class mailmerge(JSONEndpoint):
         if asm3.configuration.audit_on_send_email(dbo):
             emails = self.recipients(rows)
             asm3.audit.email(dbo, o.user, fromadd, ",".join(emails), "", "", subject, body)
+
+        #send_bulk_email(dbo: Database, replyadd: str, subject: str, body: str, rows: Results, contenttype: str, unsubscribe: bool, createlog: bool = False, logtypeid: int = 0, logmessage: str = '', username: str = '')
+        
         asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"))
 
     def post_document(self, o):

--- a/src/main.py
+++ b/src/main.py
@@ -4890,9 +4890,7 @@ class mailmerge(JSONEndpoint):
             emails = self.recipients(rows)
             asm3.audit.email(dbo, o.user, fromadd, ",".join(emails), "", "", subject, body)
 
-        #send_bulk_email(dbo: Database, replyadd: str, subject: str, body: str, rows: Results, contenttype: str, unsubscribe: bool, createlog: bool = False, logtypeid: int = 0, logmessage: str = '', username: str = '')
-        
-        asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"))
+        asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"), createlog=True, logtypeid=0, logmessage = 'Test running a unit test.', username="test")
 
     def post_document(self, o):
         dbo = o.dbo

--- a/src/main.py
+++ b/src/main.py
@@ -4890,7 +4890,7 @@ class mailmerge(JSONEndpoint):
             emails = self.recipients(rows)
             asm3.audit.email(dbo, o.user, fromadd, ",".join(emails), "", "", subject, body)
 
-        asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"), createlog=True, logtypeid=0, logmessage = 'Test running a unit test.', username="test")
+        asm3.utils.send_bulk_email(dbo, fromadd, subject, body, rows, "html", post.boolean("unsubscribe"), createlog=post.boolean("logemail"), logtypeid=post.integer("logtype"), logmessage=post["logmessage"], username="test")
 
     def post_document(self, o):
         dbo = o.dbo

--- a/src/static/js/mailmerge.js
+++ b/src/static/js/mailmerge.js
@@ -135,6 +135,15 @@ $(function() {
                 '<input id="em-includeunsubscribe" data="unsubscribe" type="checkbox" name="em-includeunsubscribe" class="asm-checkbox" />',
                 '<label for="em-includeunsubscribe">' + _("Add an unsubscribe link to the bottom of emails") + '</label>',
                 '</p>',
+
+                '<div id="em-logemail">',
+                '<input id="em-includelog" data="includelog" type="checkbox" name="em-includelog" class="asm-checkbox" />',
+                '<label for="em-includelog">' + _("Add a log to recipient person record") + '</label>',
+                '<label for="em-logtype">' + _(" using type") + '</label>',
+                '<select id="em-logtype" class="asm-selectbox">',
+                '</select>',
+                '</div>',
+
                 '</td>',
                 '<td>',
                 '<div class="ui-state-highlight ui-corner-all" style="margin-top: 5px; padding: 0 .7em;">',
@@ -270,7 +279,7 @@ $(function() {
                         $("#em-body").html(j.BODY); 
                     });
                 });
-
+                $("#em-logtype").html( html.list_to_options(controller.logtypes, 'ID', 'LOGTYPENAME') );
             }
         },
 

--- a/src/static/js/mailmerge.js
+++ b/src/static/js/mailmerge.js
@@ -116,16 +116,16 @@ $(function() {
                 hf.replace("{mode}", "email"),
                 tableform.fields_render(
                     [
-                        { id: 'em-from', label: _("From"), type: 'text', doublesize: true, validation: 'notblank' },
-                        { id: 'em-subject', label: _("Subject"), type: 'text', doublesize: true, validation: 'notblank',
+                        { id: 'em-from', post_field: 'from', label: _("From"), type: 'text', doublesize: true, validation: 'notblank' },
+                        { id: 'em-subject', post_field: 'subject', label: _("Subject"), type: 'text', doublesize: true, validation: 'notblank',
                             callout: _("Valid tokens for the subject and text") + ':' +
                             '<br/><br/>' +
                             mailmerge.render_fields()
                         },
-                        { id: 'em-body', label: _("Email body"), type: 'richtextarea', height: '200px', validation: 'notblank' },
+                        { id: 'em-body', post_field: 'body', label: _("Email body"), type: 'richtextarea', height: '200px', validation: 'notblank' },
                         { id: 'em-template', label: _("Template"), type: 'select', options: edit_header.template_list_options(controller.templates) },
-                        { id: 'em-includeunsubscribe', label: _("Add an unsubscribe link to the bottom of emails"), type: 'check' },
-                        { id: 'em-logemail', label: _("Add a log to recipient person records"), type: 'check',
+                        { id: 'em-includeunsubscribe', post_field: 'unsubscribe', post_field: 'em-includeunsubscribe', label: _("Add an unsubscribe link to the bottom of emails"), type: 'check' },
+                        { id: 'em-logemail', post_field: 'logemail', label: _("Add a log to recipient person records"), type: 'check',
                             hideif: function() {
                                 if ( controller.fields.includes("ID") || controller.fields.includes("OWNERID") ) {
                                     return false;
@@ -134,7 +134,7 @@ $(function() {
                                 }
                             }
                         },
-                        { id: 'em-logtype', label: _("Log type"), type: 'select', options: html.list_to_options(controller.logtypes, 'ID', 'LOGTYPENAME'),
+                        { id: 'em-logtype', post_field: 'logtype', label: _("Log type"), type: 'select', options: html.list_to_options(controller.logtypes, 'ID', 'LOGTYPENAME'),
                             hideif: function() {
                                 if ( controller.fields.includes("ID") || controller.fields.includes("OWNERID") ) {
                                     return false;
@@ -143,7 +143,7 @@ $(function() {
                                 }
                             }
                         },
-                        { id: 'em-logmessage', label: _("Log message"), type: 'textarea', validation: 'notblank',
+                        { id: 'em-logmessage', post_field: 'logmessage', label: _("Log message"), type: 'textarea', validation: 'notblank',
                             hideif: function() {
                                 if ( controller.fields.includes("ID") || controller.fields.includes("OWNERID") ) {
                                     return false;
@@ -232,8 +232,7 @@ $(function() {
                         validate.highlight('em-body');
                     } else {
                         $("#button-email").button("disable");
-                        let formdata = "mode=email&" + $("#sendemail input, #sendemail .asm-richtextarea, #sendemail .asm-checkbox, #sendemail .asm-selectbox").toPOST();
-                        console.log(formdata);
+                        let formdata = "mode=email&" + $("#sendemail input, #sendemail .asm-richtextarea, #sendemail .asm-selectbox, #sendemail textarea").toPOST();
                         await common.ajax_post("mailmerge", formdata);
                         header.show_info(_("Messages successfully sent"));
                         $("#asm-mailmerge-accordion").hide();

--- a/src/static/js/mailmerge.js
+++ b/src/static/js/mailmerge.js
@@ -114,48 +114,26 @@ $(function() {
                 '<h3 id="sendemailtab"><a href="#">' + _("Send emails") + '</a> (' + controller.numemails + ') ' + smcomemailinfo + '</h3>',
                 '<div id="sendemail">',
                 hf.replace("{mode}", "email"),
-                '<table width="100%">',
-                '<tr>',
-                '<td><label for="em-from">' + _("From") + '</label></td>',
-                '<td><input id="em-from" data="from" type="text" class="asm-doubletextbox" /></td>',
-                '</tr>',
-                '<tr>',
-                '<td><label for="em-subject">' + _("Subject") + '</label></td>',
-                '<td><input id="em-subject" data="subject" type="text" class="asm-doubletextbox" /></td>',
-                '</tr>',
-                '<tr>',
-                '<td colspan="2">',
-                '<div id="em-body" data="body" data-height="300px" data-margin-top="24px" class="asm-richtextarea"></div>',
-                '<p>',
-                '<label for="em-template">' + _("Template") + '</label>',
-                '<select id="em-template" class="asm-selectbox">',
-                '</select>',
-                '</p>',
-                '<p>',
-                '<input id="em-includeunsubscribe" data="unsubscribe" type="checkbox" name="em-includeunsubscribe" class="asm-checkbox" />',
-                '<label for="em-includeunsubscribe">' + _("Add an unsubscribe link to the bottom of emails") + '</label>',
-                '</p>',
-
-                '<div id="em-logemail">',
-                '<input id="em-includelog" data="includelog" type="checkbox" name="em-includelog" class="asm-checkbox" />',
-                '<label for="em-includelog">' + _("Add a log to recipient person record") + '</label>',
-                '<label for="em-logtype">' + _(" using type") + '</label>',
-                '<select id="em-logtype" class="asm-selectbox">',
-                '</select>',
-                '</div>',
-
-                '</td>',
-                '<td>',
-                '<div class="ui-state-highlight ui-corner-all" style="margin-top: 5px; padding: 0 .7em;">',
-                '<p class="centered"><span class="ui-icon ui-icon-info"></span>',
-                _("Valid tokens for the subject and text") + ':',
-                '<br/><br/>',
-                mailmerge.render_fields(),
-                '</p>',
-                '</div>',
-                '</td>',
-                '</tr>',
-                '</table>',
+                tableform.fields_render(
+                    [
+                        { id: 'em-from', label: _("From"), type: 'text', doublesize: true },
+                        { id: 'em-subject', label: _("Subject"), type: 'text', doublesize: true,
+                            callout: _("Valid tokens for the subject and text") + ':' +
+                            '<br/><br/>' +
+                            mailmerge.render_fields()
+                        },
+                        { id: 'em-body', label: _("Email body"), type: 'richtextarea', height: '200px' },
+                        { id: 'em-template', label: _("Template"), type: 'select', options: edit_header.template_list_options(controller.templates) },
+                        { id: 'em-includeunsubscribe', label: _("Add an unsubscribe link to the bottom of emails"), type: 'check' },
+                        { id: 'em-logemail', label: _("Add a log to recipient person records"), type: 'check' },
+                        { id: 'em-logtype', label: _("Log type"), type: 'select', options: html.list_to_options(controller.logtypes, 'ID', 'LOGTYPENAME') },
+                        { id: 'em-logmessage', label: _("Log message"), type: 'textarea' },
+                    ],
+                    {
+                        full_width: true
+                    }
+                ),
+                
                 '<p class="centered"><button id="button-email">' + _("Send Emails") + '</button></p>',
                 '</div>',
 

--- a/src/static/js/mailmerge.js
+++ b/src/static/js/mailmerge.js
@@ -233,6 +233,7 @@ $(function() {
                     } else {
                         $("#button-email").button("disable");
                         let formdata = "mode=email&" + $("#sendemail input, #sendemail .asm-richtextarea, #sendemail .asm-checkbox, #sendemail .asm-selectbox").toPOST();
+                        console.log(formdata);
                         await common.ajax_post("mailmerge", formdata);
                         header.show_info(_("Messages successfully sent"));
                         $("#asm-mailmerge-accordion").hide();

--- a/unittest/test_reports.py
+++ b/unittest/test_reports.py
@@ -6,6 +6,7 @@ import web062 as web
 import asm3.reports
 import asm3.utils
 import asm3.person
+import asm3.log
 
 TEST_QUERY = "SELECT * FROM lksmovementtype"
 
@@ -25,16 +26,6 @@ class TestReports(unittest.TestCase):
         post = asm3.utils.PostedData(data, "en")
         self.nid = asm3.reports.insert_report_from_form(base.get_dbo(), "test", post)
 
-        # Test Mailmerge
-        data = {
-            "title":    "Test Mailmerge",
-            "category": "Test",
-            "sql":      "SELECT ID, OwnerName, EmailAddress FROM owner",
-            "html":     "MAIL"
-        }
-        post = asm3.utils.PostedData(data, "en")
-        self.mid = asm3.reports.insert_report_from_form(base.get_dbo(), "test", post)
-
         # Test Person
         data = {
             "title": "Mr",
@@ -47,10 +38,23 @@ class TestReports(unittest.TestCase):
         post = asm3.utils.PostedData(data, "en")
         self.oid = asm3.person.insert_person_from_form(base.get_dbo(), post, "test", geocode=False)
 
+        # Test Mailmerge
+        data = {
+            "title":    "Test Mailmerge",
+            "category": "Test",
+            "sql":      f"SELECT ID, OwnerName, EmailAddress FROM owner WHERE ID = {str(self.oid)}",
+            "html":     "MAIL"
+        }
+        post = asm3.utils.PostedData(data, "en")
+        self.mid = asm3.reports.insert_report_from_form(base.get_dbo(), "test", post)
+
+        
+
     def tearDown(self):
         asm3.reports.delete_report(base.get_dbo(), "test", self.nid)
         asm3.reports.delete_report(base.get_dbo(), "test", self.mid)
         asm3.person.delete_person(base.get_dbo(), "test", self.oid)
+        base.get_dbo().execute("DELETE FROM logmulti WHERE Comments = ?", ['Created by unit test.'])
 
     def test_get_all_report_titles(self):
        self.assertNotEqual(0, len(asm3.reports.get_all_report_titles(base.get_dbo())))
@@ -85,6 +89,8 @@ class TestReports(unittest.TestCase):
     def test_smcom_reports(self):
         asm3.reports.install_recommended_smcom_reports(base.get_dbo(), "test") # Calls get_reports to do the install
 
-    def test_mailmerge(self):
+    def test_mailmerge_email_log(self):
         rows, cols = asm3.reports.execute_query(base.get_dbo(), self.mid, "test", "")
-        asm3.utils.send_bulk_email(base.get_dbo(), 'test@test.com', "Just Testing", "<p>Just a unit test email</p>", rows, contenttype="html", unsubscribe=False, createlog=True, logtypeid=0, logmessage = 'Test running a unit test.', username="test")
+        asm3.log.add_logmulti(base.get_dbo(), "test", linktype=asm3.log.PERSON, linkids=[self.oid], logtypeid=1, logtext="Created by unit test.")
+        linkids = base.get_dbo().query("SELECT LinkIDs FROM logmulti ORDER BY ID desc LIMIT 1")[0]["LINKIDS"]
+        self.assertEqual(linkids, str(self.oid))


### PR DESCRIPTION
Under the send email section of mail merges, if the field ID or OWNERID is present, allow the option to add a custom log message and type to everyone who was sent the email.

Many people have asked for this as they'd like to know when people have received their newsletters, etc. It also solves a problem for SAFE in Australia as they automatically send out unsuccessful applicant messages and would like to exclude people who have already been sent it in response to their last application.

On reflection, not sure about this, while it's popular with many, it could create a LOT of log records very fast (ironically, it would be very slow to add a thousand log records in one go).

A better solution is a way to link the same log to multiple records. Eg: with a new column containing a list of IDs or a separate table.

A separate logmulti table would be the answer for these. As well as the log message itself, it would need columns for LogTypeID, LinkTypeID and then a comma or pipe separated list of LinkIDs.

Since these messages are in a different table, it's easy enough to UNION them for the screens, but by default reports that output logs would not include them. I'm not sure if that's an issue since it's really only people that we would normally be considering for this at the moment. Print Person Record probably should include them.