### PR TITLE
Contextual reports

### DIFF
--- a/src/asm3/reports.py
+++ b/src/asm3/reports.py
@@ -44,11 +44,22 @@ def get_all_report_titles(dbo: Database):
     """
     return dbo.query("SELECT ID, Title, Category, Revision FROM customreport WHERE SQLCommand NOT LIKE '0%' AND SQLCommand NOT LIKE '%$PARENT%' ORDER BY Title")
 
-def get_ask_animal_reports(dbo: Database):
-    return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask animal%'])
+def get_ask_animal_reports(dbo: Database, superuser: int, roleids: str):
+    filteredreports = []
+    allreports = dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask animal$%'])
+    roles = dbo.query("SELECT * FROM customreportrole")
+    for report in allreports:
+        viewroleids = []
+        for role in roles:
+            if role.REPORTID == report.ID and role.CANVIEW == 1:
+                viewroleids.append(str(role.ROLEID))
+        report.VIEWROLEIDS = "|".join(viewroleids)
+        if superuser or report.VIEWROLEIDS == "" or asm3.utils.list_overlap(report.VIEWROLEIDS.split("|"), roleids.split("|")):
+            filteredreports.append(report)
+    return filteredreports
 
 def get_ask_person_reports(dbo: Database):
-    return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask person%'])
+    return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask person$%'])
 
 def get_available_reports(dbo: Database, include_with_criteria: bool = True) -> Results:
     """

--- a/src/asm3/reports.py
+++ b/src/asm3/reports.py
@@ -44,6 +44,10 @@ def get_all_report_titles(dbo: Database):
     """
     return dbo.query("SELECT ID, Title, Category, Revision FROM customreport WHERE SQLCommand NOT LIKE '0%' AND SQLCommand NOT LIKE '%$PARENT%' ORDER BY Title")
 
+def get_ask_animal_reports(dbo: Database):
+    ilike = dbo.sql_ilike("SQLCommand", "?")
+    return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask animal%'])
+
 def get_available_reports(dbo: Database, include_with_criteria: bool = True) -> Results:
     """
     Returns a list of reports available for running. The return

--- a/src/asm3/reports.py
+++ b/src/asm3/reports.py
@@ -48,6 +48,10 @@ def get_ask_animal_reports(dbo: Database):
     ilike = dbo.sql_ilike("SQLCommand", "?")
     return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask animal%'])
 
+def get_ask_person_reports(dbo: Database):
+    ilike = dbo.sql_ilike("SQLCommand", "?")
+    return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask person%'])
+
 def get_available_reports(dbo: Database, include_with_criteria: bool = True) -> Results:
     """
     Returns a list of reports available for running. The return

--- a/src/asm3/reports.py
+++ b/src/asm3/reports.py
@@ -45,11 +45,9 @@ def get_all_report_titles(dbo: Database):
     return dbo.query("SELECT ID, Title, Category, Revision FROM customreport WHERE SQLCommand NOT LIKE '0%' AND SQLCommand NOT LIKE '%$PARENT%' ORDER BY Title")
 
 def get_ask_animal_reports(dbo: Database):
-    ilike = dbo.sql_ilike("SQLCommand", "?")
     return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask animal%'])
 
 def get_ask_person_reports(dbo: Database):
-    ilike = dbo.sql_ilike("SQLCommand", "?")
     return dbo.query(f"SELECT ID, Title, Category, Revision FROM customreport WHERE {dbo.sql_ilike("SQLCommand", "?")} ORDER BY Title", ['%$ask person%'])
 
 def get_available_reports(dbo: Database, include_with_criteria: bool = True) -> Results:

--- a/src/main.py
+++ b/src/main.py
@@ -6318,7 +6318,7 @@ class person(JSONEndpoint):
             "homecheckhistory": asm3.person.get_homechecked(dbo, p.id),
             "jurisdictions": asm3.lookups.get_jurisdictions(dbo),
             "logtypes": asm3.lookups.get_log_types(dbo),
-            "reports": asm3.reports.get_ask_person_reports(dbo),
+            "reports": asm3.reports.get_ask_person_reports(dbo, o['session'].superuser, o['session'].roleids),
             "sexes": asm3.lookups.get_sexes(dbo),
             "sites": asm3.lookups.get_sites(dbo),
             "sizes": asm3.lookups.get_sizes(dbo),

--- a/src/main.py
+++ b/src/main.py
@@ -1876,7 +1876,7 @@ class animal(JSONEndpoint):
             "pickuplocations": asm3.lookups.get_pickup_locations(dbo),
             "publishhistory": asm3.animal.get_publish_history(dbo, a.ID),
             "posneg": asm3.lookups.get_posneg(dbo),
-            "reports": asm3.reports.get_ask_animal_reports(dbo, o['session'].superuser, o['session'].roleids),
+            "reports": asm3.reports.get_ask_animal_reports(dbo, o["session"].superuser, o["session"].roleids),
             "returnedexitmovements": asm3.animal.get_returned_exit_movements(dbo, a.ID),
             "sexes": asm3.lookups.get_sexes(dbo),
             "sizes": asm3.lookups.get_sizes(dbo),
@@ -2860,7 +2860,7 @@ class change_user_settings(JSONEndpoint):
         quicklinks = post["quicklinksid"]
         quickreports = post["quickreportsid"]
         quickreportscfg = []
-        reports = asm3.reports.Mail(o.dbo)
+        reports = asm3.reports.get_reports(o.dbo)
         if quickreports != "":
             for reportid in quickreports.split(","):
                 for report in reports:
@@ -6318,7 +6318,7 @@ class person(JSONEndpoint):
             "homecheckhistory": asm3.person.get_homechecked(dbo, p.id),
             "jurisdictions": asm3.lookups.get_jurisdictions(dbo),
             "logtypes": asm3.lookups.get_log_types(dbo),
-            "reports": asm3.reports.get_ask_person_reports(dbo, o['session'].superuser, o['session'].roleids),
+            "reports": asm3.reports.get_ask_person_reports(dbo, o["session"].superuser, o["session"].roleids),
             "sexes": asm3.lookups.get_sexes(dbo),
             "sites": asm3.lookups.get_sites(dbo),
             "sizes": asm3.lookups.get_sizes(dbo),

--- a/src/main.py
+++ b/src/main.py
@@ -1876,7 +1876,7 @@ class animal(JSONEndpoint):
             "pickuplocations": asm3.lookups.get_pickup_locations(dbo),
             "publishhistory": asm3.animal.get_publish_history(dbo, a.ID),
             "posneg": asm3.lookups.get_posneg(dbo),
-            "reports": asm3.reports.get_ask_animal_reports(dbo),
+            "reports": asm3.reports.get_ask_animal_reports(dbo, o['session'].superuser, o['session'].roleids),
             "returnedexitmovements": asm3.animal.get_returned_exit_movements(dbo, a.ID),
             "sexes": asm3.lookups.get_sexes(dbo),
             "sizes": asm3.lookups.get_sizes(dbo),
@@ -2860,7 +2860,7 @@ class change_user_settings(JSONEndpoint):
         quicklinks = post["quicklinksid"]
         quickreports = post["quickreportsid"]
         quickreportscfg = []
-        reports = asm3.reports.get_reports(o.dbo)
+        reports = asm3.reports.Mail(o.dbo)
         if quickreports != "":
             for reportid in quickreports.split(","):
                 for report in reports:

--- a/src/main.py
+++ b/src/main.py
@@ -6318,6 +6318,7 @@ class person(JSONEndpoint):
             "homecheckhistory": asm3.person.get_homechecked(dbo, p.id),
             "jurisdictions": asm3.lookups.get_jurisdictions(dbo),
             "logtypes": asm3.lookups.get_log_types(dbo),
+            "reports": asm3.reports.get_ask_person_reports(dbo),
             "sexes": asm3.lookups.get_sexes(dbo),
             "sites": asm3.lookups.get_sites(dbo),
             "sizes": asm3.lookups.get_sizes(dbo),

--- a/src/main.py
+++ b/src/main.py
@@ -1876,6 +1876,7 @@ class animal(JSONEndpoint):
             "pickuplocations": asm3.lookups.get_pickup_locations(dbo),
             "publishhistory": asm3.animal.get_publish_history(dbo, a.ID),
             "posneg": asm3.lookups.get_posneg(dbo),
+            "reports": asm3.reports.get_ask_animal_reports(dbo),
             "returnedexitmovements": asm3.animal.get_returned_exit_movements(dbo, a.ID),
             "sexes": asm3.lookups.get_sexes(dbo),
             "sizes": asm3.lookups.get_sizes(dbo),

--- a/src/static/js/animal.js
+++ b/src/static/js/animal.js
@@ -531,7 +531,7 @@ $(function() {
                 '</ul>',
                 '</div>',
                 '<div id="button-report-body" class="asm-menu-body">',
-                edit_header.report_list(controller.reports, controller.animal.ID),
+                edit_header.animal_report_list(controller.reports, controller.animal.ID),
                 '</ul>',
                 '</div>',
                 '<div id="dialog-clone-confirm" style="display: none" title="' + html.title(_("Clone")) + '">',

--- a/src/static/js/animal.js
+++ b/src/static/js/animal.js
@@ -530,6 +530,12 @@ $(function() {
                 edit_header.template_list(controller.templates, "ANIMAL", controller.animal.ID),
                 '</ul>',
                 '</div>',
+
+                '<div id="button-report-body" class="asm-menu-body">',
+                edit_header.report_list(controller.reports, controller.animal.ID),
+                '</ul>',
+                '</div>',
+
                 '<div id="dialog-clone-confirm" style="display: none" title="' + html.title(_("Clone")) + '">',
                 '<p><span class="ui-icon ui-icon-alert"></span> ' + _("Clone this animal?") + '</p>',
                 '</div>',
@@ -574,6 +580,7 @@ $(function() {
                     { id: "delete", text: _("Delete"), icon: "delete", tooltip: _("Delete this animal") },
                     { id: "email", text: _("Email"), icon: "email", tooltip: _("Send an email relating to this animal") },
                     { id: "document", text: _("Document"), type: "buttonmenu", icon: "document", tooltip: _("Generate a document from this animal") },
+                    { id: "report", text: _("Report"), type: "buttonmenu", icon: "report", tooltip: _("Generate a report from this animal") },
                     { id: "newentry", text: _("New Entry"), icon: "new", tooltip: _("Generate a new code and archive the current entry data"),
                         hideif: function() { 
                             return config.bool("DisableEntryHistory") || 
@@ -952,10 +959,11 @@ $(function() {
             if (!common.has_permission("da")) { $("#button-delete").hide(); }
             if (!common.has_permission("emo")) { $("#button-email").hide(); }
             if (!common.has_permission("gaf")) { $("#button-document").hide(); }
+            if (!common.has_permission("")) { $("#button-report").hide(); }
             if (!common.has_permission("vo")) { $("#button-currentowner").hide(); }
             if (!common.has_permission("mlaf")) { $("#button-match").hide(); }
             if (!common.has_permission("vll")) { $("#button-littermates").hide(); }
-            if (!common.has_permission("uipb")) { $("#button-share").hide(); }
+            if (!common.has_permission("vcr")) { $("#button-report").hide(); }
 
             // ACCORDION ICONS =======================================================
 
@@ -1134,6 +1142,10 @@ $(function() {
 
             // Setup the document/social menu buttons
             $("#button-document, #button-share").asmmenu();
+
+            $("#button-report").asmmenu();
+
+
 
             $("#emailform").emailform();
 

--- a/src/static/js/animal.js
+++ b/src/static/js/animal.js
@@ -530,12 +530,10 @@ $(function() {
                 edit_header.template_list(controller.templates, "ANIMAL", controller.animal.ID),
                 '</ul>',
                 '</div>',
-
                 '<div id="button-report-body" class="asm-menu-body">',
                 edit_header.report_list(controller.reports, controller.animal.ID),
                 '</ul>',
                 '</div>',
-
                 '<div id="dialog-clone-confirm" style="display: none" title="' + html.title(_("Clone")) + '">',
                 '<p><span class="ui-icon ui-icon-alert"></span> ' + _("Clone this animal?") + '</p>',
                 '</div>',
@@ -959,11 +957,10 @@ $(function() {
             if (!common.has_permission("da")) { $("#button-delete").hide(); }
             if (!common.has_permission("emo")) { $("#button-email").hide(); }
             if (!common.has_permission("gaf")) { $("#button-document").hide(); }
-            if (!common.has_permission("")) { $("#button-report").hide(); }
+            if (!common.has_permission("vcr")) { $("#button-report").hide(); }
             if (!common.has_permission("vo")) { $("#button-currentowner").hide(); }
             if (!common.has_permission("mlaf")) { $("#button-match").hide(); }
             if (!common.has_permission("vll")) { $("#button-littermates").hide(); }
-            if (!common.has_permission("vcr")) { $("#button-report").hide(); }
 
             // ACCORDION ICONS =======================================================
 
@@ -1141,11 +1138,7 @@ $(function() {
         bind: function() {
 
             // Setup the document/social menu buttons
-            $("#button-document, #button-share").asmmenu();
-
-            $("#button-report").asmmenu();
-
-
+            $("#button-document, #button-share, #button-report").asmmenu();
 
             $("#emailform").emailform();
 

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -824,7 +824,7 @@ edit_header = {
 
     // List of reports that contain '$ask animal$'
     animal_report_list: function(reports, animalid) {
-        var s = [];
+        var s = ['<ul class="asm-menu-list">'];
         var lastcategory = "";
         $.each(reports, function(i, r) {
             if (r.CATEGORY != lastcategory) {
@@ -833,12 +833,13 @@ edit_header = {
             }
             s.push('<li class="asm-menu-item"><a target="_blank" class="templatelink" data="' + r.ID + '" href="/report?id=' + r.ID + '&hascriteria=true&ASK1=' + animalid + '">' + r.TITLE + '</a></li>');
         });
+        s.push('</ul>');
         return s.join("\n");
     },
 
     // List of reports that contain '$ask person$'
     person_report_list: function(reports, personid) {
-        var s = [];
+        var s = ['<ul class="asm-menu-list">'];
         var lastcategory = "";
         $.each(reports, function(i, r) {
             if (r.CATEGORY != lastcategory) {
@@ -847,6 +848,7 @@ edit_header = {
             }
             s.push('<li class="asm-menu-item"><a target="_blank" class="templatelink" data="' + r.ID + '" href="/report?id=' + r.ID + '&hascriteria=true&ASK1=' + personid + '">' + r.TITLE + '</a></li>');
         });
+        s.push('</ul>');
         return s.join("\n");
     },
 

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -822,6 +822,20 @@ edit_header = {
         return s.join("\n");
     },
 
+    // List of reports that contain '$ask animal' embedded
+    report_list: function(reports, animalid) {
+        var s = [];
+        var lastcategory = "";
+        $.each(reports, function(i, r) {
+            if (r.CATEGORY != lastcategory) {
+                s.push('<li class="asm-menu-category">' + r.CATEGORY + '</li>');
+                lastcategory = r.CATEGORY;
+            }
+            s.push('<li class="asm-menu-item"><a target="_blank" class="templatelink" data="' + r.ID + '" href="/report?id=' + r.ID + '&hascriteria=true&ASK1=' + animalid + '">' + r.TITLE + '</a></li>');
+        });
+        return s.join("\n");
+    },
+
     /**
      * Returns option tags from a list of HTML document templates.
      * The values are the template IDs

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -822,8 +822,8 @@ edit_header = {
         return s.join("\n");
     },
 
-    // List of reports that contain '$ask animal'
-    report_list: function(reports, animalid) {
+    // List of reports that contain '$ask animal$'
+    animal_report_list: function(reports, animalid) {
         var s = [];
         var lastcategory = "";
         $.each(reports, function(i, r) {
@@ -832,6 +832,20 @@ edit_header = {
                 lastcategory = r.CATEGORY;
             }
             s.push('<li class="asm-menu-item"><a target="_blank" class="templatelink" data="' + r.ID + '" href="/report?id=' + r.ID + '&hascriteria=true&ASK1=' + animalid + '">' + r.TITLE + '</a></li>');
+        });
+        return s.join("\n");
+    },
+
+    // List of reports that contain '$ask person$'
+    person_report_list: function(reports, personid) {
+        var s = [];
+        var lastcategory = "";
+        $.each(reports, function(i, r) {
+            if (r.CATEGORY != lastcategory) {
+                s.push('<li class="asm-menu-category">' + r.CATEGORY + '</li>');
+                lastcategory = r.CATEGORY;
+            }
+            s.push('<li class="asm-menu-item"><a target="_blank" class="templatelink" data="' + r.ID + '" href="/report?id=' + r.ID + '&hascriteria=true&ASK1=' + personid + '">' + r.TITLE + '</a></li>');
         });
         return s.join("\n");
     },

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -822,7 +822,7 @@ edit_header = {
         return s.join("\n");
     },
 
-    // List of reports that contain '$ask animal' embedded
+    // List of reports that contain '$ask animal'
     report_list: function(reports, animalid) {
         var s = [];
         var lastcategory = "";

--- a/src/static/js/person.js
+++ b/src/static/js/person.js
@@ -222,6 +222,7 @@ $(function() {
                 { id: "anonymise", text: _("Anonymize"), icon: "delete", tooltip: _("Remove personally identifiable data") },
                 { id: "merge", text: _("Merge"), icon: "copy", tooltip: _("Merge another person into this one") },
                 { id: "document", text: _("Document"), type: "buttonmenu", icon: "document", tooltip: _("Generate a document from this person") },
+                { id: "report", text: _("Report"), type: "buttonmenu", icon: "report", tooltip: _("Generate a report from this person") },
                 { id: "lookingfor", text: _("Looking For"), icon: "animal-find", tooltip: _("Find animals matching the looking for criteria of this person") },
                 { id: "map", text: _("Map"), icon: "map", tooltip: _("Find this address on a map") },
                 { id: "email", text: _("Email"), icon: "email", tooltip: _("Email this person") }
@@ -233,6 +234,10 @@ $(function() {
                 '<div id="button-document-body" class="asm-menu-body">',
                 '<ul class="asm-menu-list">',
                 edit_header.template_list(controller.templates, "PERSON", controller.person.ID),
+                '</ul>',
+                '</div>',
+                '<div id="button-report-body" class="asm-menu-body">',
+                edit_header.report_list(controller.reports, controller.person.ID),
                 '</ul>',
                 '</div>',
             ].join("\n");
@@ -402,6 +407,7 @@ $(function() {
             if (!common.has_permission("co")) { $("#button-save, #button-anonymise").hide(); }
             if (!common.has_permission("do")) { $("#button-delete, #button-anonymise").hide(); }
             if (!common.has_permission("gaf")) { $("#button-document").hide(); }
+            if (!common.has_permission("vcr")) { $("#button-report").hide(); }
             if (!common.has_permission("mo")) { $("#button-merge").hide(); }
 
             // ACCORDION ICONS =======================================================
@@ -476,7 +482,7 @@ $(function() {
             }); 
 
             // Setup the document menu button
-            $("#button-document").asmmenu();
+            $("#button-document, #button-report").asmmenu();
             
             // Email dialog for sending emails
             $("#emailform").emailform();

--- a/src/static/js/person.js
+++ b/src/static/js/person.js
@@ -237,7 +237,7 @@ $(function() {
                 '</ul>',
                 '</div>',
                 '<div id="button-report-body" class="asm-menu-body">',
-                edit_header.report_list(controller.reports, controller.person.ID),
+                edit_header.person_report_list(controller.reports, controller.person.ID),
                 '</ul>',
                 '</div>',
             ].join("\n");


### PR DESCRIPTION
User suggestion, on the animal and person details screens have a "Reports" dropdown next to Documents.

The new dropdown should filter/show all reports with a single A S K A N I M A L or A S K P E R S O N tag in their source (new get_reports query).

The target link for each one is the normal link for the report with the extra parameters &mode=exec&ASK1=[ID]

This allows reports for the currently viewed record to be run without being asked for one.