### PR TITLE
Allow diary/calendar colour coding

### DIFF
--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3782,7 +3782,7 @@ def update_animals_from_form(dbo: Database, username: str, post: PostedData) -> 
     if post["diaryfor"] != "" and post.date("diarydate") is not None and post["diarysubject"] != "":
         for animalid in post.integer_list("animals"):
             asm3.diary.insert_diary(dbo, username, asm3.diary.ANIMAL, animalid, post.datetime("diarydate", "diarytime"), 
-                post["diaryfor"], post["diarysubject"], post["diarynotes"])
+                post["diaryfor"], post["diarysubject"], post["diarynotes"], colourschemeid=post.integer("diarycolourscheme"))
     if post.integer("logtype") != -1:
         for animalid in post.integer_list("animals"):
             asm3.log.add_log(dbo, username, asm3.log.ANIMAL, animalid, post.integer("logtype"), post["lognotes"], post.date("logdate") )

--- a/src/asm3/diary.py
+++ b/src/asm3/diary.py
@@ -383,7 +383,7 @@ def insert_diary_from_form(dbo: Database, username: str, linktypeid: int, linkid
         email_note_on_change(dbo, get_diary(dbo, diaryid), username)
     return diaryid
 
-def insert_diary(dbo: Database, username: str, linktypeid: int, linkid: int, diarydate: datetime, diaryfor: str, subject: str, note: str, emailnow: bool = False) -> int:
+def insert_diary(dbo: Database, username: str, linktypeid: int, linkid: int, diarydate: datetime, diaryfor: str, subject: str, note: str, emailnow: bool = False, colourschemeid: int = 0) -> int:
     """
     Creates a diary note from the form data
     username: User creating the diary
@@ -402,6 +402,7 @@ def insert_diary(dbo: Database, username: str, linktypeid: int, linkid: int, dia
         "LinkInfo":         linkinfo,
         "DiaryDateTime":    diarydate,
         "DiaryForName":     diaryfor,
+        "ColourSchemeID":   colourschemeid,
         "Subject":          subject,
         "Note":             note
     }, username)
@@ -471,10 +472,12 @@ def execute_diary_task(dbo: Database, username: str, tasktype: int, taskid: int,
             rollingdate = asm3.i18n.add_days(rollingdate, int(d.DAYPIVOT))
         if d.WHOFOR == "taskcreator":
             d.WHOFOR = username
-        insert_diary(dbo, username, linktype, linkid, rollingdate, \
-            d.WHOFOR, \
-            asm3.wordprocessor.substitute_tags(d.SUBJECT, tags), \
-            asm3.wordprocessor.substitute_tags(d.NOTE, tags))
+        insert_diary(dbo, username, linktype, linkid, rollingdate,
+            d.WHOFOR, 
+            asm3.wordprocessor.substitute_tags(d.SUBJECT, tags),
+            asm3.wordprocessor.substitute_tags(d.NOTE, tags),
+            colourschemeid=d.COLOURSCHEMEID
+            )
 
 def insert_diarytaskhead_from_form(dbo: Database, username: str, post: PostedData) -> int:
     """
@@ -512,6 +515,7 @@ def insert_diarytaskdetail_from_form(dbo: Database, username: str, post: PostedD
         "OrderIndex":           post.integer("orderindex"),
         "DayPivot":             post.integer("pivot"),
         "WhoFor":               post["for"],
+        "ColourSchemeID":       post["diarycolourscheme"],
         "Subject":              post["subject"],
         "Note":                 post["note"],
         "RecordVersion":        0
@@ -525,6 +529,7 @@ def update_diarytaskdetail_from_form(dbo: Database, username: str, post: PostedD
         "OrderIndex":           post.integer("orderindex"),
         "DayPivot":             post.integer("pivot"),
         "WhoFor":               post["for"],
+        "ColourSchemeID":       post["diarycolourscheme"],
         "Subject":              post["subject"],
         "Note":                 post["note"]
     }, username, setLastChanged=False)

--- a/src/asm3/diary.py
+++ b/src/asm3/diary.py
@@ -372,6 +372,7 @@ def insert_diary_from_form(dbo: Database, username: str, linktypeid: int, linkid
         "LinkInfo":         linkinfo,
         "DiaryDateTime":    post.datetime("diarydate", "diarytime"),
         "DiaryForName":     post["diaryfor"],
+        "ColourSchemeID":   post["diarycolourscheme"],
         "Subject":          post["subject"],
         "Note":             post["note"],
         "Comments":         post["comments"],
@@ -431,6 +432,7 @@ def update_diary_from_form(dbo: Database, username: str, post: PostedData) -> No
     dbo.update("diary", diaryid, {
         "DiaryDateTime":    post.datetime("diarydate", "diarytime"),
         "DiaryForName":     post["diaryfor"],
+        "ColourSchemeID":   post["diarycolourscheme"],
         "Subject":          post["subject"],
         "Note":             post["note"],
         "Comments":         post["comments"],

--- a/src/asm3/event.py
+++ b/src/asm3/event.py
@@ -79,6 +79,17 @@ def get_animals_by_event(dbo: Database, eventid: int, queryfilter: str = "all") 
         ae["AGEGROUP"] = asm3.animal.calc_age_group(dbo, ae["ANIMALID"])
     return rows
 
+def get_events_two_dates(dbo: Database, start: datetime, end: datetime) -> Results:
+    """
+    Returns all events that are active between two dates
+    """
+    return dbo.query(get_event_query(dbo) + "WHERE " \
+        "(ev.StartDateTime <= ? AND ? >= ev.StartDateTime) OR " \
+        "(ev.StartDateTime >= ? AND ? <= ev.EndDateTime) OR " \
+        "(ev.StartDateTime <= ? AND ? >= ev.EndDateTime) " \
+        "ORDER BY ev.StartDateTime", 
+        [start, end, start, end, end, end])
+
 def get_events_by_date(dbo: Database, date: datetime) -> Results:
     """
     Returns all events that match date

--- a/src/asm3/event.py
+++ b/src/asm3/event.py
@@ -79,17 +79,6 @@ def get_animals_by_event(dbo: Database, eventid: int, queryfilter: str = "all") 
         ae["AGEGROUP"] = asm3.animal.calc_age_group(dbo, ae["ANIMALID"])
     return rows
 
-def get_events_two_dates(dbo: Database, start: datetime, end: datetime) -> Results:
-    """
-    Returns all events that are active between two dates
-    """
-    return dbo.query(get_event_query(dbo) + "WHERE " \
-        "(ev.StartDateTime <= ? AND ? >= ev.StartDateTime) OR " \
-        "(ev.StartDateTime >= ? AND ? <= ev.EndDateTime) OR " \
-        "(ev.StartDateTime <= ? AND ? >= ev.EndDateTime) " \
-        "ORDER BY ev.StartDateTime", 
-        [start, end, start, end, end, end])
-
 def get_events_by_date(dbo: Database, date: datetime) -> Results:
     """
     Returns all events that match date

--- a/src/asm3/html.py
+++ b/src/asm3/html.py
@@ -1024,3 +1024,5 @@ def thumbnail_img_src(dbo: Database, row: ResultRow, mode: str) -> str:
             uri += "&date=%s" % row.WEBSITEMEDIADATE.isoformat()
         return uri
 
+def get_colour_schemes(dbo: Database):
+    return dbo.query('SELECT * FROM lkscolourscheme ORDER BY ColourSchemeName')

--- a/src/asm3/html.py
+++ b/src/asm3/html.py
@@ -1022,7 +1022,4 @@ def thumbnail_img_src(dbo: Database, row: ResultRow, mode: str) -> str:
         uri = f"image?db={dbo.name()}&mode={mode}&id={str(idval)}"
         if "WEBSITEMEDIADATE" in row and row.WEBSITEMEDIADATE is not None:
             uri += "&date=%s" % row.WEBSITEMEDIADATE.isoformat()
-        return uri
-
-def get_colour_schemes(dbo: Database):
-    return dbo.query('SELECT * FROM lkscolourscheme ORDER BY ColourSchemeName')
+        return UserWarning

--- a/src/asm3/html.py
+++ b/src/asm3/html.py
@@ -1022,4 +1022,4 @@ def thumbnail_img_src(dbo: Database, row: ResultRow, mode: str) -> str:
         uri = f"image?db={dbo.name()}&mode={mode}&id={str(idval)}"
         if "WEBSITEMEDIADATE" in row and row.WEBSITEMEDIADATE is not None:
             uri += "&date=%s" % row.WEBSITEMEDIADATE.isoformat()
-        return UserWarning
+        return uri

--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -91,9 +91,26 @@ LOOKUP_MODIFIERS = 4
 LOOKUP_FOREIGNKEYS = 5
 
 COLOURSCHEMES = [
-    { "ID": 1, "SCHEMENAME": _("Standard"), "FGCOL": "", "BGCOL": "" },
-    { "ID": 2, "SCHEMENAME": _("Important"), "FGCOL": "red", "BGCOL": "yellow" },
-    { "ID": 3, "SCHEMENAME": _("Weird"), "FGCOL": "green", "BGCOL": "orange" }
+    { "ID": 1, "FGCOL": "", "BGCOL": "" },
+    { "ID": 2, "FGCOL": "#515151", "BGCOL": "#e7e7e7" },
+    { "ID": 3, "FGCOL": "#103b79", "BGCOL": "#b6cff5" },
+    { "ID": 4, "FGCOL": "#472893", "BGCOL": "#e3d7ff" },
+    { "ID": 5, "FGCOL": "#78203d", "BGCOL": "#98d7e4" },
+    { "ID": 6, "FGCOL": "#8b1900", "BGCOL": "#f2b2a8" },
+    { "ID": 7, "FGCOL": "#fafafa", "BGCOL": "#c2c2c2" },
+    { "ID": 8, "FGCOL": "#f7f9fe", "BGCOL": "#4986e7" },
+    { "ID": 9, "FGCOL": "#fbfdfe", "BGCOL": "#2da2bb" },
+    { "ID": 10, "FGCOL": "#fefdff", "BGCOL": "#b99aff" },
+    { "ID": 11, "FGCOL": "#9e4e69", "BGCOL": "#f691b2" },
+    { "ID": 12, "FGCOL": "#fff3f3", "BGCOL": "#f94b2f" },
+    { "ID": 13, "FGCOL": "#874023", "BGCOL": "#ffc8af" },
+    { "ID": 14, "FGCOL": "#7b4700", "BGCOL": "#ffdeb5" },
+    { "ID": 15, "FGCOL": "#594c02", "BGCOL": "#fbe983" },
+    { "ID": 16, "FGCOL": "#694e00", "BGCOL": "#fdedc1" },
+    { "ID": 17, "FGCOL": "#065332", "BGCOL": "#b3efd3" },
+    { "ID": 18, "FGCOL": "#fffbfa", "BGCOL": "#ff7537" },
+    { "ID": 19, "FGCOL": "#fffdfb", "BGCOL": "#ffad46" },
+    { "ID": 20, "FGCOL": "#7f5158", "BGCOL": "#ebdbde" },
 ]
 
 # Currency codes used by payment processors when accepting payments

--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -90,6 +90,12 @@ LOOKUP_DESCFIELD = 3
 LOOKUP_MODIFIERS = 4
 LOOKUP_FOREIGNKEYS = 5
 
+COLOURSCHEMES = [
+    { "ID": 1, "SCHEMENAME": _("Standard"), "FGCOL": "", "BGCOL": "" },
+    { "ID": 2, "SCHEMENAME": _("Important"), "FGCOL": "red", "BGCOL": "yellow" },
+    { "ID": 3, "SCHEMENAME": _("Weird"), "FGCOL": "green", "BGCOL": "orange" }
+]
+
 # Currency codes used by payment processors when accepting payments
 CURRENCIES = [
     { "CODE": "USD", "DISPLAY": "USD - United States Dollar"},

--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -110,7 +110,7 @@ COLOURSCHEMES = [
     { "ID": 17, "FGCOL": "#065332", "BGCOL": "#b3efd3" },
     { "ID": 18, "FGCOL": "#fffbfa", "BGCOL": "#ff7537" },
     { "ID": 19, "FGCOL": "#fffdfb", "BGCOL": "#ffad46" },
-    { "ID": 20, "FGCOL": "#7f5158", "BGCOL": "#ebdbde" },
+    { "ID": 20, "FGCOL": "#7f5158", "BGCOL": "#ebdbde" }
 ]
 
 # Currency codes used by payment processors when accepting payments

--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -113,6 +113,19 @@ COLOURSCHEMES = [
     { "ID": 20, "FGCOL": "#7f5158", "BGCOL": "#ebdbde" }
 ]
 
+CALENDAR_EVENT_COLOURSCHEMES = {
+    "vaccination": ["#FFE797", "#84994F"],
+    "medical": ["#B45253", "#FCB53B"],
+    "test": ["#48B3AF", "#476EAE"],
+    "boarding": ["#0BA6DF", "#EF7722"],
+    "clinic": ["#84994F", "#FFE797"],
+    "payment": ["#FCB53B", "#B45253"],
+    "incident": ["#476EAE", "#48B3AF"],
+    "transport": ["#EF7722", "#0BA6DF" ],
+    "equipment": ["#FFFFFF",  "#000000"],
+    "event": ["#331B3F", "#ACC7B4" ]
+}
+
 # Currency codes used by payment processors when accepting payments
 CURRENCIES = [
     { "CODE": "USD", "DISPLAY": "USD - United States Dollar"},

--- a/src/main.py
+++ b/src/main.py
@@ -2725,6 +2725,7 @@ class calendar_events(ASMEndpoint):
                     "fgcol": fgcol,
                     "bgcol": bgcol }),
         if "v" in ev and self.checkb(asm3.users.VIEW_VACCINATION):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["vaccination"]
             for v in asm3.medical.get_vaccinations_two_dates(dbo, start, end, o.lf):
                 sub = "%s - %s" % (v.VACCINATIONTYPE, v.ANIMALNAME)
                 tit = "%s - %s %s (%s) %s" % (v.VACCINATIONTYPE, v.SHELTERCODE, v.ANIMALNAME, v.DISPLAYLOCATIONNAME, v.COMMENTS)
@@ -2734,7 +2735,9 @@ class calendar_events(ASMEndpoint):
                     "start": v.DATEREQUIRED, 
                     "tooltip": tit, 
                     "icon": "vaccination",
-                    "link": "animal_vaccination?id=%s" % v.ANIMALID })
+                    "link": "animal_vaccination?id=%s" % v.ANIMALID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
             for v in asm3.medical.get_vaccinations_expiring_two_dates(dbo, start, end, o.lf):
                 sub = "%s - %s" % (v.VACCINATIONTYPE, v.ANIMALNAME)
                 tit = "%s - %s %s (%s) %s" % (v.VACCINATIONTYPE, v.SHELTERCODE, v.ANIMALNAME, v.DISPLAYLOCATIONNAME, v.COMMENTS)
@@ -2744,8 +2747,11 @@ class calendar_events(ASMEndpoint):
                     "start": v.DATEEXPIRES, 
                     "tooltip": tit, 
                     "icon": "vaccination",
-                    "link": "animal_vaccination?id=%s" % v.ANIMALID })
+                    "link": "animal_vaccination?id=%s" % v.ANIMALID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "m" in ev and self.checkb(asm3.users.VIEW_MEDICAL):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["medical"]
             for m in asm3.medical.get_treatments_two_dates(dbo, start, end, o.lf):
                 sub = "%s - %s" % (m.TREATMENTNAME, m.ANIMALNAME)
                 tit = "%s - %s %s (%s) %s %s" % (m.TREATMENTNAME, m.SHELTERCODE, m.ANIMALNAME, m.DISPLAYLOCATIONNAME, m.DOSAGE, m.COMMENTS)
@@ -2755,8 +2761,11 @@ class calendar_events(ASMEndpoint):
                     "start": m.DATEREQUIRED, 
                     "tooltip": tit, 
                     "icon": "medical",
-                    "link": "animal_medical?id=%s" % m.ANIMALID })
+                    "link": "animal_medical?id=%s" % m.ANIMALID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "t" in ev and self.checkb(asm3.users.VIEW_TEST):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["test"]
             for t in asm3.medical.get_tests_two_dates(dbo, start, end, o.lf):
                 sub = "%s - %s" % (t.TESTNAME, t.ANIMALNAME)
                 tit = "%s - %s %s (%s) %s" % (t.TESTNAME, t.SHELTERCODE, t.ANIMALNAME, t.DISPLAYLOCATIONNAME, t.COMMENTS)
@@ -2766,8 +2775,11 @@ class calendar_events(ASMEndpoint):
                     "start": t.DATEREQUIRED, 
                     "tooltip": tit, 
                     "icon": "test",
-                    "link": "animal_test?id=%s" % t.ANIMALID })
+                    "link": "animal_test?id=%s" % t.ANIMALID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "b" in ev and self.checkb(asm3.users.VIEW_BOARDING):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["boarding"]
             for b in asm3.financial.get_boarding_due_two_dates(dbo, start, end):
                 sub = "%s:%s - %s" % (b.SHELTERLOCATIONNAME, b.SHELTERLOCATIONUNIT, b.ANIMALNAME)
                 tit = "%s:%s - %s, %s" % (b.SHELTERLOCATIONNAME, b.SHELTERLOCATIONUNIT, b.ANIMALNAME, b.OWNERNAME)
@@ -2778,8 +2790,11 @@ class calendar_events(ASMEndpoint):
                     "end": b.OUTDATETIME,
                     "tooltip": tit, 
                     "icon": "boarding",
-                    "link": "animal_boarding?id=%s" % b.ANIMALID })
+                    "link": "animal_boarding?id=%s" % b.ANIMALID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "c" in ev and self.checkb(asm3.users.VIEW_CLINIC):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["clinic"]
             for c in asm3.clinic.get_appointments_two_dates(dbo, start, end, o.post["apptfor"], o.siteid):
                 if c.OWNERNAME is not None:
                     sub = "%s - %s" % (c.OWNERNAME, c.ANIMALNAME)
@@ -2796,8 +2811,11 @@ class calendar_events(ASMEndpoint):
                     "end": add_minutes(c.DATETIME, 20),
                     "tooltip": tit, 
                     "icon": "health",
-                    "link": link })
+                    "link": link,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "p" in ev and self.checkb(asm3.users.VIEW_DONATION):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["payment"]
             for p in asm3.financial.get_donations_due_two_dates(dbo, start, end):
                 sub = "%s - %s" % (p.DONATIONNAME, p.OWNERNAME)
                 tit = "%s - %s %s %s" % (p.DONATIONNAME, p.OWNERNAME, format_currency(l, p.DONATION), p.COMMENTS)
@@ -2807,8 +2825,11 @@ class calendar_events(ASMEndpoint):
                     "start": p.DATEDUE, 
                     "tooltip": tit, 
                     "icon": "donation",
-                    "link": "person_donations?id=%s" % p.OWNERID })
+                    "link": "person_donations?id=%s" % p.OWNERID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "o" in ev and self.checkb(asm3.users.VIEW_INCIDENT):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["incident"]
             for o in asm3.animalcontrol.get_followup_two_dates(dbo, start, end):
                 sub = "%s - %s" % (o.INCIDENTNAME, o.OWNERNAME)
                 tit = "%s - %s %s, %s" % (o.INCIDENTNAME, o.OWNERNAME, o.DISPATCHADDRESS, o.CALLNOTES)
@@ -2818,8 +2839,11 @@ class calendar_events(ASMEndpoint):
                     "start": o.FOLLOWUPDATETIME, 
                     "tooltip": tit, 
                     "icon": "call",
-                    "link": "incident?id=%s" % o.ACID })
+                    "link": "incident?id=%s" % o.ACID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "r" in ev and self.checkb(asm3.users.VIEW_TRANSPORT):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["transport"]
             for r in asm3.movement.get_transport_two_dates(dbo, start, end):
                 sub = "%s - %s" % (r.ANIMALNAME, r.SHELTERCODE)
                 tit = "%s %s, %s - %s :: %s, %s" % (r.ANIMALNAME, r.SHELTERCODE, r.DRIVEROWNERNAME, r.PICKUPOWNERADDRESS, r.DROPOFFOWNERADDRESS, r.COMMENTS)
@@ -2833,8 +2857,11 @@ class calendar_events(ASMEndpoint):
                     "end": r.DROPOFFDATETIME,
                     "tooltip": tit, 
                     "icon": "transport",
-                    "link": "animal_transport?id=%s" % r.ANIMALID})
+                    "link": "animal_transport?id=%s" % r.ANIMALID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "l" in ev and self.checkb(asm3.users.VIEW_TRAPLOAN):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["equipment"]
             for l in asm3.animalcontrol.get_traploan_two_dates(dbo, start, end):
                 sub = "%s - %s" % (l.TRAPTYPENAME, l.OWNERNAME)
                 tit = "%s - %s %s, %s" % (l.TRAPTYPENAME, l.OWNERNAME, l.TRAPNUMBER, l.COMMENTS)
@@ -2844,12 +2871,14 @@ class calendar_events(ASMEndpoint):
                     "start": l.RETURNDUEDATE, 
                     "tooltip": tit, 
                     "icon": "traploan",
-                    "link": "person_traploan?id=%s" % l.OWNERID})
+                    "link": "person_traploan?id=%s" % l.OWNERID,
+                    "fgcol": fgcol,
+                    "bgcol": bgcol })
         if "e" in ev and self.checkb(asm3.users.VIEW_EVENT):
+            fgcol, bgcol = asm3.lookups.CALENDAR_EVENT_COLOURSCHEMES["event"]
             now = start
             while now <= end:
                 eventsdata = asm3.event.get_events_by_date(dbo, now)
-                # eventsdata = asm3.event.get_events_two_dates(dbo, start, end)
                 for e in eventsdata:
                     events.append({ 
                         "title": e.EVENTNAME, 
@@ -2857,7 +2886,9 @@ class calendar_events(ASMEndpoint):
                         "start": now, 
                         "tooltip": e.EVENTDESCRIPTION, 
                         "icon": "event",
-                        "link": "event?id=%s" % e.ID})
+                        "link": "event?id=%s" % e.ID,
+                        "fgcol": fgcol,
+                        "bgcol": bgcol })
                 now = asm3.i18n.add_days(now, 1)
         asm3.al.debug("calendarview found %d events (%s->%s)" % (len(events), start, end), "main.calendarview", dbo)
         self.content_type("application/json")

--- a/src/main.py
+++ b/src/main.py
@@ -4080,7 +4080,7 @@ class foundanimal_find(JSONEndpoint):
             "species": asm3.lookups.get_species(dbo),
             "breeds": asm3.lookups.get_breeds_by_species(dbo),
             "sexes": asm3.lookups.get_sexes(dbo),
-            "mode": "found",
+            "mode": "found"
         }
 
 class foundanimal_find_results(JSONEndpoint):

--- a/src/main.py
+++ b/src/main.py
@@ -2845,6 +2845,20 @@ class calendar_events(ASMEndpoint):
                     "tooltip": tit, 
                     "icon": "traploan",
                     "link": "person_traploan?id=%s" % l.OWNERID})
+        if "e" in ev and self.checkb(asm3.users.VIEW_EVENT):
+            now = start
+            while now <= end:
+                eventsdata = asm3.event.get_events_by_date(dbo, now)
+                # eventsdata = asm3.event.get_events_two_dates(dbo, start, end)
+                for e in eventsdata:
+                    events.append({ 
+                        "title": e.EVENTNAME, 
+                        "allDay": True, 
+                        "start": now, 
+                        "tooltip": e.EVENTDESCRIPTION, 
+                        "icon": "event",
+                        "link": "event?id=%s" % e.ID})
+                now = asm3.i18n.add_days(now, 1)
         asm3.al.debug("calendarview found %d events (%s->%s)" % (len(events), start, end), "main.calendarview", dbo)
         self.content_type("application/json")
         return asm3.utils.json(events)

--- a/src/main.py
+++ b/src/main.py
@@ -2005,7 +2005,8 @@ class animal_bulk(JSONEndpoint):
             "forlist": asm3.users.get_diary_forlist(dbo),
             "internallocations": asm3.lookups.get_internal_locations(dbo, o.lf),
             "logtypes": asm3.lookups.get_log_types(dbo),
-            "movementtypes": asm3.lookups.get_movement_types(dbo)
+            "movementtypes": asm3.lookups.get_movement_types(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
     def post_update(self, o):
@@ -2104,7 +2105,7 @@ class animal_diary(JSONEndpoint):
             "linktypeid": asm3.diary.ANIMAL,
             "diarytasks": asm3.diary.get_animal_tasks(dbo),
             "forlist": asm3.users.get_diary_forlist(dbo),
-            "colourschemes": asm3.html.get_colour_schemes(dbo)
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class animal_diet(JSONEndpoint):
@@ -2667,7 +2668,7 @@ class calendarview(JSONEndpoint):
     get_permissions = asm3.users.VIEW_ANIMAL
 
     def controller(self, o):
-        return { "colourschemes": asm3.html.get_colour_schemes(o.dbo) }
+        return { "colourschemes": asm3.lookups.COLOURSCHEMES }
 
 class calendar_events(ASMEndpoint):
     url = "calendar_events"
@@ -2675,7 +2676,7 @@ class calendar_events(ASMEndpoint):
     def extract_colours(self, colourschemes, schemeid):
         for scheme in colourschemes:
             if scheme["ID"] == schemeid:
-                return [ scheme["FOREGROUNDCOLOUR"], scheme["BACKGROUNDCOLOUR"] ]
+                return [ scheme["FGCOL"], scheme["BGCOL"] ]
         return []
 
     def content(self, o):
@@ -2688,7 +2689,7 @@ class calendar_events(ASMEndpoint):
         user = o.user
         dbo = o.dbo
         l = o.locale
-        colourschemes = asm3.html.get_colour_schemes(o.dbo)
+        colourschemes = asm3.lookups.COLOURSCHEMES
         if "d" in ev and self.checkb(asm3.users.VIEW_DIARY):
             # Show all diary notes on the calendar if the user chose to see all
             # on the home page, or they have permission to view all notes
@@ -3234,7 +3235,7 @@ class diary_edit(JSONEndpoint):
             "linkid": 0,
             "linktypeid": asm3.diary.NO_LINK,
             "forlist": asm3.users.get_diary_forlist(dbo),
-            "colourschemes": asm3.html.get_colour_schemes(dbo)
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class diary_edit_my(JSONEndpoint):
@@ -3262,7 +3263,7 @@ class diary_edit_my(JSONEndpoint):
             "linkid": 0,
             "linktypeid": asm3.diary.NO_LINK,
             "forlist": asm3.users.get_diary_forlist(dbo),
-            "colourschemes": asm3.html.get_colour_schemes(dbo)
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class diarytask(JSONEndpoint):
@@ -3280,7 +3281,8 @@ class diarytask(JSONEndpoint):
             "rows": diarytaskdetail,
             "taskid": taskid,
             "taskname": taskname,
-            "forlist": asm3.users.get_diary_forlist(dbo)
+            "forlist": asm3.users.get_diary_forlist(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
     def post_create(self, o):
@@ -4059,7 +4061,8 @@ class foundanimal_diary(JSONEndpoint):
             "name": "foundanimal_diary",
             "linkid": a["LFID"],
             "linktypeid": asm3.diary.FOUNDANIMAL,
-            "forlist": asm3.users.get_diary_forlist(dbo)
+            "forlist": asm3.users.get_diary_forlist(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class foundanimal_find(JSONEndpoint):
@@ -4077,7 +4080,7 @@ class foundanimal_find(JSONEndpoint):
             "species": asm3.lookups.get_species(dbo),
             "breeds": asm3.lookups.get_breeds_by_species(dbo),
             "sexes": asm3.lookups.get_sexes(dbo),
-            "mode": "found"
+            "mode": "found",
         }
 
 class foundanimal_find_results(JSONEndpoint):
@@ -4381,7 +4384,8 @@ class incident_diary(JSONEndpoint):
             "name": "incident_diary",
             "linkid": a["ACID"],
             "linktypeid": asm3.diary.ANIMALCONTROL,
-            "forlist": asm3.users.get_diary_forlist(dbo)
+            "forlist": asm3.users.get_diary_forlist(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class incident_log(JSONEndpoint):
@@ -4730,7 +4734,8 @@ class lostanimal_diary(JSONEndpoint):
             "name": "lostanimal_diary",
             "linkid": a["LFID"],
             "linktypeid": asm3.diary.LOSTANIMAL,
-            "forlist": asm3.users.get_diary_forlist(dbo)
+            "forlist": asm3.users.get_diary_forlist(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class lostanimal_find(JSONEndpoint):
@@ -6479,7 +6484,8 @@ class person_diary(JSONEndpoint):
             "linkid": p["ID"],
             "linktypeid": asm3.diary.PERSON,
             "diarytasks": asm3.diary.get_person_tasks(dbo),
-            "forlist": asm3.users.get_diary_forlist(dbo)
+            "forlist": asm3.users.get_diary_forlist(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class person_donations(JSONEndpoint):
@@ -8207,7 +8213,8 @@ class waitinglist_diary(JSONEndpoint):
             "name": "waitinglist_diary",
             "linkid": a["WLID"],
             "linktypeid": asm3.diary.WAITINGLIST,
-            "forlist": asm3.users.get_diary_forlist(dbo)
+            "forlist": asm3.users.get_diary_forlist(dbo),
+            "colourschemes": asm3.lookups.COLOURSCHEMES
         }
 
 class waitinglist_log(JSONEndpoint):

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1090,7 +1090,6 @@ select:disabled, input:disabled, textarea:disabled {
     position: relative;
     padding: 2px;
     cursor: default;
-    font-weight: bold;
 }
 .asm-colourscheme {
     height: 24px;

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1086,6 +1086,32 @@ select:disabled, input:disabled, textarea:disabled {
     white-space: nowrap;
 }
 
+.asm-selectedcolourscheme {
+    position: relative;
+    padding: 2px;
+    cursor: default;
+    font-weight: bold;
+}
+.asm-colourscheme {
+    height: 24px;
+    border-radius: 12px;
+    width: 24px;
+    cursor: default;
+    display: inline-block;
+    font-weight: bold;
+    text-align: center;
+    margin-right: 1px;
+    margin-bottom: 1px;
+}
+.asm-colourschemes {
+    display: none;
+    position: absolute;
+    top: 0;
+    /* right: 0; */
+    left: 200px;
+    width: 113px;
+}
+
 /** Tweaks for when displaying on portrait mobile devices */
 @media screen and (max-device-width:480px) {
 

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1106,7 +1106,6 @@ select:disabled, input:disabled, textarea:disabled {
     display: none;
     position: absolute;
     top: 0;
-    /* right: 0; */
     left: 200px;
     width: 113px;
 }

--- a/src/static/js/animal_bulk.js
+++ b/src/static/js/animal_bulk.js
@@ -97,6 +97,9 @@ $(function() {
                             tableform.render_time({ post_field: "diarytime", halfsize: true, justwidget: true }) 
                             ].join("\n")
                     },
+                    { post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", 
+                        options: { rows: controller.colourschemes, displayfield: "SCHEMENAME", valuefield: "ID" }
+                    },
                     { post_field: "diarysubject", label: _("Subject"), type: "text" },
                     { post_field: "diarynotes", label: _(""), labelpos: "above", type: "textarea", colclasses: "bottomborder" }
                 ], { full_width: false }),

--- a/src/static/js/animal_bulk.js
+++ b/src/static/js/animal_bulk.js
@@ -97,8 +97,7 @@ $(function() {
                             tableform.render_time({ post_field: "diarytime", halfsize: true, justwidget: true }) 
                             ].join("\n")
                     },
-                    { post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", 
-                        options: { rows: controller.colourschemes, displayfield: "SCHEMENAME", valuefield: "ID" }
+                    { post_field: "diarycolourscheme", label: _("Color Scheme"), type: "raw", defaultval: 1, callout: _("The color scheme to be used when displaying this note on the calendar view"), markup: '<div class="colourschemeid"></div>'
                     },
                     { post_field: "diarysubject", label: _("Subject"), type: "text" },
                     { post_field: "diarynotes", label: _(""), labelpos: "above", type: "textarea", colclasses: "bottomborder" }
@@ -198,7 +197,7 @@ $(function() {
                 if (!validate.notblank([ "animals" ])) { return; }
                 $("#button-update").button("disable");
                 header.show_loading(_("Updating..."));
-                let formdata = "mode=update&" + $("input, select, textarea").not(".chooser").toPOST();
+                let formdata = "mode=update&diarycolourscheme=" + $(".colourschemeid").colouredselectmenu("value") + "&" + $("input, select, textarea").not(".chooser").toPOST();
                 try {
                     let response = await common.ajax_post("animal_bulk", formdata);
                     header.hide_loading();
@@ -251,6 +250,8 @@ $(function() {
 
             $("#updateadditional").change(animal_bulk.updateadditional_change);
             animal_bulk.updateadditional_change();
+
+            $(".colourschemeid").colouredselectmenu();
 
         },
 

--- a/src/static/js/calendarview.js
+++ b/src/static/js/calendarview.js
@@ -84,7 +84,7 @@ $(function() {
                         element.css("border-color", event.bgcol);
                     }
                     if (event.link) { 
-                        title.wrap('<a style="color: #fff" href="' + event.link + '"></a>');
+                        title.wrap('<a style="color: inherit" href="' + event.link + '"></a>');
                         listtitle.prop("href", event.link);
                         if (event.tooltip) { listtitle.html(event.tooltip); } // Use the more detailed version in the list
                     }

--- a/src/static/js/calendarview.js
+++ b/src/static/js/calendarview.js
@@ -46,6 +46,7 @@ $(function() {
                 chk("toggle-incident", "o", "call", _("Incident followup")),
                 chk("toggle-transport", "r", "transport", _("Transport")),
                 chk("toggle-traploan", "l", "traploan", _("Equipment loan")),
+                chk("toggle-event", "e", "event", _("Event")),
                 '</p>',
                 '<div id="calendar" style="max-width: 900px; margin-left: auto; margin-right: auto;"></div>',
                 html.content_footer()
@@ -73,7 +74,7 @@ $(function() {
                     listtitle.html(event.title);
                     // We extend the default event object to support tooltips and icons
                     if (event.tooltip) { 
-                        element.prop("title", html.decode(event.tooltip)); 
+                        element.prop("title", html.decode(html.strip_tags(event.tooltip))); 
                     }
                     if (event.fgcol) {
                         element.css("color", event.fgcol);
@@ -129,6 +130,7 @@ $(function() {
             if (config.bool("DisableClinic")) { $(".tagclinic").hide(); }
             if (config.bool("DisableTransport")) { $(".tagtransport").hide(); }
             if (config.bool("DisableTrapLoan")) { $(".tagtraploan").hide(); }
+            if (config.bool("DisableEvents")) { $(".tagevent").hide(); }
         },
 
         delay: function() {

--- a/src/static/js/common_widgets.js
+++ b/src/static/js/common_widgets.js
@@ -754,13 +754,13 @@ $.widget( "asm.iconselectmenu", $.ui.selectmenu, {
  */
 $.widget( "asm.colouredselectmenu", {
     _create: function() {
-        let self = this
+        let self = this;
         let htmllines = [
             '<div style="position: relative;">',
             '<div class="asm-selectedcolourscheme asm-field asm-textbox" data-schemeid="0">' + _("Color Scheme") + '</div>',
             '<div class="asm-colourschemeexpand" style="position: absolute;left: 182px;top: 3px;font-size: 0.8em;cursor: default;">&#9654;</div>',
             '<div class="asm-colourschemes asm-textbox">',
-        ]
+        ];
         $.each(controller.colourschemes, function(i, v) {
             htmllines.push('<div class="asm-colourscheme" data-schemeid="' + v.ID + '" style="background-color: ' + v.BGCOL + ';color: ' + v.FGCOL + ';">a</div>');
         });
@@ -782,15 +782,11 @@ $.widget( "asm.colouredselectmenu", {
         let scheme = $(".asm-colourscheme[data-schemeid='" + schemeid + "']");
         let fgcol = scheme.css("color");
         let bgcol = scheme.css("background-color");
-        // console.log(schemeid);
-        // let schemename = scheme.html();
         let selectedschemediv = this.element.find(".asm-selectedcolourscheme");
         selectedschemediv.attr("data-schemeid", schemeid);
-        // selectedschemediv.html(schemename);
         selectedschemediv.css("background-color", bgcol);
         selectedschemediv.css("color", fgcol);
         this.element.find(".asm-colourschemeexpand").css("color", fgcol);
-        // this.element.val(schemeid);
     },
     value: function(newval) {
         if (newval === undefined) {

--- a/src/static/js/common_widgets.js
+++ b/src/static/js/common_widgets.js
@@ -782,14 +782,15 @@ $.widget( "asm.colouredselectmenu", {
         let scheme = $(".asm-colourscheme[data-schemeid='" + schemeid + "']");
         let fgcol = scheme.css("color");
         let bgcol = scheme.css("background-color");
-        let schemename = scheme.html();
+        // console.log(schemeid);
+        // let schemename = scheme.html();
         let selectedschemediv = this.element.find(".asm-selectedcolourscheme");
         selectedschemediv.attr("data-schemeid", schemeid);
         // selectedschemediv.html(schemename);
         selectedschemediv.css("background-color", bgcol);
         selectedschemediv.css("color", fgcol);
         this.element.find(".asm-colourschemeexpand").css("color", fgcol);
-        this.element.val(schemeid);
+        // this.element.val(schemeid);
     },
     value: function(newval) {
         if (newval === undefined) {

--- a/src/static/js/common_widgets.js
+++ b/src/static/js/common_widgets.js
@@ -749,6 +749,57 @@ $.widget( "asm.iconselectmenu", $.ui.selectmenu, {
     }
 });
 
+/** 
+ * JQuery UI select menu with custom rendering for option colours
+ */
+$.widget( "asm.colouredselectmenu", {
+    _create: function() {
+        let self = this
+        let htmllines = [
+            '<div style="position: relative;">',
+            '<div class="asm-selectedcolourscheme asm-field asm-textbox" data-schemeid="0">' + _("Color Scheme") + '</div>',
+            '<div class="asm-colourschemeexpand" style="position: absolute;left: 182px;top: 3px;font-size: 0.8em;cursor: default;">&#9654;</div>',
+            '<div class="asm-colourschemes asm-textbox">',
+        ]
+        $.each(controller.colourschemes, function(i, v) {
+            htmllines.push('<div class="asm-colourscheme" data-schemeid="' + v.ID + '" style="background-color: ' + v.BGCOL + ';color: ' + v.FGCOL + ';">a</div>');
+        });
+        htmllines.push('</div>');
+        htmllines.push('</div>');
+        this.element.append(htmllines.join("\n"));
+        $(".asm-selectedcolourscheme, .asm-colourschemeexpand").click(function() {
+            $(".asm-colourschemes").toggle();
+        });
+        $(".asm-colourscheme").click(function(e) {
+            let scheme = $(e.target);
+            let schemeid = scheme.attr("data-schemeid");
+            self.change_selection(schemeid);
+            $(".asm-colourschemes").hide();
+            
+        });
+    },
+    change_selection: function(schemeid) {
+        let scheme = $(".asm-colourscheme[data-schemeid='" + schemeid + "']");
+        let fgcol = scheme.css("color");
+        let bgcol = scheme.css("background-color");
+        let schemename = scheme.html();
+        let selectedschemediv = this.element.find(".asm-selectedcolourscheme");
+        selectedschemediv.attr("data-schemeid", schemeid);
+        // selectedschemediv.html(schemename);
+        selectedschemediv.css("background-color", bgcol);
+        selectedschemediv.css("color", fgcol);
+        this.element.find(".asm-colourschemeexpand").css("color", fgcol);
+        this.element.val(schemeid);
+    },
+    value: function(newval) {
+        if (newval === undefined) {
+            return $(".asm-selectedcolourscheme").attr("data-schemeid");
+        }
+        if (!newval) { newval = ""; }
+        this.change_selection(newval);
+    }
+});
+
 /**
  * Widget to create a payment dialog.
  * Target should be a div to contain the hidden dialog.

--- a/src/static/js/diary.js
+++ b/src/static/js/diary.js
@@ -18,6 +18,13 @@ $(function() {
                 fields: [
                     { json_field: "DIARYFORNAME", post_field: "diaryfor", label: _("For"), type: "select", 
                         options: { rows: controller.forlist, displayfield: "USERNAME", valuefield: "USERNAME" }},
+                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", defaultval: 1,
+                        options: { rows: controller.colourschemes, displayfield: "COLOURSCHEMENAME", valuefield: "ID" },
+                        hideif: function() {
+                            if (!controller.colourschemes) { return true } else { return false };
+                        },
+                        callout: _("The color scheme to be used when displaying this note on the calendar view")
+                    },
                     { json_field: "DIARYDATETIME", post_field: "diarydate", label: _("Date"), type: "date", validation: "notblank", defaultval: new Date() },
                     { json_field: "DIARYDATETIME", post_field: "diarytime", label: _("Time"), type: "time" },
                     { json_field: "DATECOMPLETED", post_field: "completed", label: _("Completed"), type: "date" },

--- a/src/static/js/diary.js
+++ b/src/static/js/diary.js
@@ -7,6 +7,10 @@ $(function() {
     const diary = {
 
         model: function() {
+            let colourschemeoptionshtml = "";
+            controller.colourschemes.forEach(function(v) {
+                colourschemeoptionshtml += '<option value="' + v.ID + '" data-bgcol="' + v.BGCOL + '" data-fgcol="' + v.FGCOL + '">' + v.SCHEMENAME + '</option>';
+            });
             const dialog = {
                 add_title: _("Add diary"),
                 edit_title: _("Edit diary"),
@@ -18,9 +22,7 @@ $(function() {
                 fields: [
                     { json_field: "DIARYFORNAME", post_field: "diaryfor", label: _("For"), type: "select", 
                         options: { rows: controller.forlist, displayfield: "USERNAME", valuefield: "USERNAME" }},
-                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", defaultval: "1",
-                        options: { rows: controller.colourschemes, displayfield: "SCHEMENAME", valuefield: "ID" },
-                        callout: _("The color scheme to be used when displaying this note on the calendar view")
+                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color"), type: "raw", defaultval: 1, callout: _("The color scheme to be used when displaying this note on the calendar view"), markup: '<div class="colourschemeid"></div>'
                     },
                     { json_field: "DIARYDATETIME", post_field: "diarydate", label: _("Date"), type: "date", validation: "notblank", defaultval: new Date() },
                     { json_field: "DIARYDATETIME", post_field: "diarytime", label: _("Time"), type: "time" },
@@ -37,11 +39,12 @@ $(function() {
                 idcolumn: "ID",
                 edit: function(row) {
                     tableform.fields_populate_from_json(dialog.fields, row);
+                    $(".colourschemeid").colouredselectmenu("value", row.COLOURSCHEMEID);
                     tableform.dialog_show_edit(dialog, row, {
                         onchange: async function() {
                             try {
                                 tableform.fields_update_row(dialog.fields, row);
-                                await tableform.fields_post(dialog.fields, "mode=update&diaryid=" + row.ID, "diary");
+                                await tableform.fields_post(dialog.fields, "mode=update&diaryid=" + row.ID + "&diarycolourscheme=" + $(".colourschemeid").colouredselectmenu("value"), "diary");
                                 tableform.table_update(table);
                                 tableform.dialog_close();
                             }
@@ -215,6 +218,7 @@ $(function() {
         },
 
         bind: function() {
+            $(".colourschemeid").colouredselectmenu();
             $(".asm-tabbar").asmtabs();
             $("#button-diarytask").asmmenu();
             tableform.dialog_bind(this.dialog);
@@ -276,7 +280,7 @@ $(function() {
         new_note: function() {
             tableform.dialog_show_add(diary.dialog, {
                 onadd: async function() {
-                    let response = await tableform.fields_post(diary.dialog.fields, "mode=create&linktypeid=" + controller.linktypeid + "&linkid=" + controller.linkid, "diary");
+                    let response = await tableform.fields_post(diary.dialog.fields, "mode=create&linktypeid=" + controller.linktypeid + "&linkid=" + controller.linkid + "&diarycolourscheme=" + $(".colourschemeid").colouredselectmenu("value"), "diary");
                     let row = {};
                     row.ID = response;
                     tableform.fields_update_row(diary.dialog.fields, row);
@@ -299,6 +303,8 @@ $(function() {
                     if (config.str("AFDefaultDiaryPerson")) {
                         $("#diaryfor").select("value", config.str("AFDefaultDiaryPerson"));
                     }
+
+                    $(".colourschemeid").colouredselectmenu("value", 1);
                 }
             });
         },

--- a/src/static/js/diary.js
+++ b/src/static/js/diary.js
@@ -22,7 +22,7 @@ $(function() {
                 fields: [
                     { json_field: "DIARYFORNAME", post_field: "diaryfor", label: _("For"), type: "select", 
                         options: { rows: controller.forlist, displayfield: "USERNAME", valuefield: "USERNAME" }},
-                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color"), type: "raw", defaultval: 1, callout: _("The color scheme to be used when displaying this note on the calendar view"), markup: '<div class="colourschemeid"></div>'
+                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme very, very long label"), type: "raw", defaultval: 1, callout: _("The color scheme to be used when displaying this note on the calendar view"), markup: '<div class="colourschemeid"></div>'
                     },
                     { json_field: "DIARYDATETIME", post_field: "diarydate", label: _("Date"), type: "date", validation: "notblank", defaultval: new Date() },
                     { json_field: "DIARYDATETIME", post_field: "diarytime", label: _("Time"), type: "time" },
@@ -230,6 +230,8 @@ $(function() {
         },
 
         bind: function() {
+            $("#dialog-tableform table tr td").first().css("max-width", "150px");
+            $("#dialog-tableform table tr td").first().css("width", "150px");
             $(".colourschemeid").colouredselectmenu();
             $(".asm-tabbar").asmtabs();
             $("#button-diarytask").asmmenu();

--- a/src/static/js/diary.js
+++ b/src/static/js/diary.js
@@ -22,7 +22,7 @@ $(function() {
                 fields: [
                     { json_field: "DIARYFORNAME", post_field: "diaryfor", label: _("For"), type: "select", 
                         options: { rows: controller.forlist, displayfield: "USERNAME", valuefield: "USERNAME" }},
-                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme very, very long label"), type: "raw", defaultval: 1, callout: _("The color scheme to be used when displaying this note on the calendar view"), markup: '<div class="colourschemeid"></div>'
+                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme"), type: "raw", defaultval: 1, callout: _("The color scheme to be used when displaying this note on the calendar view"), markup: '<div class="colourschemeid"></div>'
                     },
                     { json_field: "DIARYDATETIME", post_field: "diarydate", label: _("Date"), type: "date", validation: "notblank", defaultval: new Date() },
                     { json_field: "DIARYDATETIME", post_field: "diarytime", label: _("Time"), type: "time" },
@@ -44,6 +44,7 @@ $(function() {
                         onchange: async function() {
                             try {
                                 tableform.fields_update_row(dialog.fields, row);
+                                row.COLOURSCHEMEID = $(".colourschemeid").colouredselectmenu("value");
                                 await tableform.fields_post(dialog.fields, "mode=update&diaryid=" + row.ID + "&diarycolourscheme=" + $(".colourschemeid").colouredselectmenu("value"), "diary");
                                 tableform.table_update(table);
                                 tableform.dialog_close();
@@ -230,7 +231,7 @@ $(function() {
         },
 
         bind: function() {
-            $("#dialog-tableform table tr td").first().css("max-width", "150px");
+            // $("#dialog-tableform table tr td").first().css("max-width", "150px");
             $("#dialog-tableform table tr td").first().css("width", "150px");
             $(".colourschemeid").colouredselectmenu();
             $(".asm-tabbar").asmtabs();
@@ -302,15 +303,6 @@ $(function() {
                     diary.set_extra_fields(row);
                     controller.rows.push(row);
                     tableform.table_update(diary.table);
-                    let fgcol = "";
-                    let bgcol = "";
-                    $.each(controller.colourschemes, function(i, v) {
-                        if (v.ID == row.COLOURSCHEMEID) {
-                            fgcol = v.FGCOL;
-                            bgcol = v.BGCOL;
-                        }
-                    });
-                    $("#row-" + row.ID + " .asm-diarysubjectcoldiv").css("background-color", bgcol);
                     tableform.dialog_close();
                 },
                 onload: function() {

--- a/src/static/js/diary.js
+++ b/src/static/js/diary.js
@@ -102,7 +102,19 @@ $(function() {
                             return common.current_url().indexOf("diary_edit") == -1;
                         }
                     },
-                    { field: "SUBJECT", display: _("Subject") },
+                    { field: "SUBJECT", display: _("Subject"),
+                        formatter: function(row) {
+                            let fgcol = "";
+                            let bgcol = "";
+                            $.each(controller.colourschemes, function(i, v) {
+                                if (v.ID == row.COLOURSCHEMEID) {
+                                    fgcol = v.FGCOL;
+                                    bgcol = v.BGCOL;
+                                }
+                            });
+                            return '<div class="asm-diarysubjectcoldiv" style="background-color: ' + bgcol + '; color: ' + fgcol + ';">' + row.SUBJECT + '</div>';
+                        },
+                    },
                     { field: "NOTE", display: _("Note") },
                     { field: "CREATEDBY", display: _("By") }
                 ]
@@ -281,12 +293,22 @@ $(function() {
             tableform.dialog_show_add(diary.dialog, {
                 onadd: async function() {
                     let response = await tableform.fields_post(diary.dialog.fields, "mode=create&linktypeid=" + controller.linktypeid + "&linkid=" + controller.linkid + "&diarycolourscheme=" + $(".colourschemeid").colouredselectmenu("value"), "diary");
-                    let row = {};
-                    row.ID = response;
+                    var row = {};
+                    row.ID = parseInt(response);
                     tableform.fields_update_row(diary.dialog.fields, row);
+                    row.COLOURSCHEMEID = $(".colourschemeid").colouredselectmenu("value");
                     diary.set_extra_fields(row);
                     controller.rows.push(row);
                     tableform.table_update(diary.table);
+                    let fgcol = "";
+                    let bgcol = "";
+                    $.each(controller.colourschemes, function(i, v) {
+                        if (v.ID == row.COLOURSCHEMEID) {
+                            fgcol = v.FGCOL;
+                            bgcol = v.BGCOL;
+                        }
+                    });
+                    $("#row-" + row.ID + " .asm-diarysubjectcoldiv").css("background-color", bgcol);
                     tableform.dialog_close();
                 },
                 onload: function() {

--- a/src/static/js/diary.js
+++ b/src/static/js/diary.js
@@ -18,11 +18,8 @@ $(function() {
                 fields: [
                     { json_field: "DIARYFORNAME", post_field: "diaryfor", label: _("For"), type: "select", 
                         options: { rows: controller.forlist, displayfield: "USERNAME", valuefield: "USERNAME" }},
-                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", defaultval: 1,
-                        options: { rows: controller.colourschemes, displayfield: "COLOURSCHEMENAME", valuefield: "ID" },
-                        hideif: function() {
-                            if (!controller.colourschemes) { return true } else { return false };
-                        },
+                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", defaultval: "1",
+                        options: { rows: controller.colourschemes, displayfield: "SCHEMENAME", valuefield: "ID" },
                         callout: _("The color scheme to be used when displaying this note on the calendar view")
                     },
                     { json_field: "DIARYDATETIME", post_field: "diarydate", label: _("Date"), type: "date", validation: "notblank", defaultval: new Date() },

--- a/src/static/js/diarytask.js
+++ b/src/static/js/diarytask.js
@@ -22,6 +22,10 @@ $(function() {
                         callout: _("Create note this many days from today, or 9999 to ask"), validation: "notblank" },
                     { json_field: "WHOFOR", post_field: "for", label: _("For"), type: "select", 
                         options: { rows: controller.forlist, displayfield: "USERNAME", valuefield: "USERNAME", prepend: ('<option value="taskcreator">' + _("(task creator)") + '</option>') }},
+                    { json_field: "COLOURSCHEMEID", post_field: "diarycolourscheme", label: _("Color Scheme"), type: "select", defaultval: "Standard",
+                        options: { rows: controller.colourschemes, displayfield: "SCHEMENAME", valuefield: "ID" },
+                        callout: _("The color scheme to be used when displaying this note on the calendar view")
+                    },
                     { json_field: "SUBJECT", label: _("Subject"), post_field: "subject", validation: "notblank", type: "text" },
                     { json_field: "NOTE", label: _("Note"), post_field: "note", validation: "notblank", type: "textarea" }
                 ]


### PR DESCRIPTION
The calendarview.js code now supports bgcol and fgcol in the events sent to it.

Add a new integer field to the diary table for colour. This value is an index to an internal table of background/foreground colour values that the user can choose from when creating their diary note. The two values will be sent to calendarview.js for that event so that users can effectively colour code their diary notes.

It is also possible that we could have some fixed colours for the different types of calendar elements, such as medical items, clinic, etc.