### PR TITLE
Online forms: Allow breed dropdown fields to use the species selector

### DIFF
--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -337,7 +337,13 @@ def get_onlineform_html(dbo: Database, formid: int, completedocument: bool = Tru
         elif f.FIELDTYPE == FIELDTYPE_BREED:
             h.append('<select class="asm-onlineform-breed" id="%s" name="%s" %s>' % ( fid, cname, required))
             h.append('<option value=""></option>')
-            for l in asm3.lookups.get_breeds(dbo):
+            if f.SPECIESID and f.SPECIESID > 0:
+                breeds = asm3.lookups.get_breeds_by_species(dbo)
+            else:
+                breeds = asm3.lookups.get_breeds(dbo)
+            for l in breeds:
+                if f.SPECIESID and f.SPECIESID > 0 and l.SPECIESID != f.SPECIESID:
+                    continue
                 if l.ISRETIRED != 1:
                     h.append('<option>%s</option>' % l.BREEDNAME)
             h.append('</select>')

--- a/src/static/js/onlineform.js
+++ b/src/static/js/onlineform.js
@@ -174,7 +174,7 @@ $(function() {
                 $("label[for='lookups']").html(_("Lookups"));
                 $("#lookupsrow").fadeOut();
             }
-            if (ft == 4 || ft == 5 || ft == 21) {
+            if (ft == 4 || ft == 5 || ft == 21 || ft == 7) {
                 $("#speciesrow").fadeIn();
             }
             else {


### PR DESCRIPTION
We already have a SPECIESID column on form fields for use with the adoptable, shelter and foster animal field types. This same column could also work with the breed type (ID 7).

All it would need to work is displaying for ID 7 in onlineform.js and in onlineform.py/get_onlineform_html to use asm3.lookups.get_breeds_by_species instead of get_breeds if all isn't selected.