### PR TITLE
feat: Add date brought in field to online form import

### DIFF
--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -113,7 +113,7 @@ FORM_FIELDS = [
     "datelost", "datefound", "arealost", "areafound", "areapostcode", "areazipcode", "microchip",
     "animalname", "animalname2", "animalname3", "reserveanimalname", "reserveanimalname2", "reserveanimalname3",
     "code", "microchip", "age", "dateofbirth", "entryreason", "entrytype", "markings", "comments", "hiddencomments", "healthproblems", 
-    "type", "breed1", "breed2", "color", "sex", "neutered", "weight", "commentsanimal", 
+    "type", "breed1", "breed2", "color", "sex", "neutered", "weight", "datebroughtin", "commentsanimal", 
     "callnotes", "dispatchaddress", "dispatchcity", "dispatchstate", "dispatchzipcode", "transporttype", 
     "pickupaddress", "pickuptown", "pickupcity", "pickupcounty", "pickupstate", "pickuppostcode", "pickupzipcode", "pickupcountry", "pickupdate", "pickuptime",
     "dropoffaddress", "dropofftown", "dropoffcity", "dropoffcounty", "dropoffstate", "dropoffpostcode", "dropoffzipcode", "dropoffcountry", "dropoffdate", "dropofftime",
@@ -1457,7 +1457,7 @@ def create_animal(dbo: Database, username: str, collationid: int, broughtinby: i
     status is 0 for created, 1 for updated existing
     "animalname", "code", "microchip", "age", "dateofbirth", "entryreason", "markings", 
     "comments", "commentsanimal", "hiddencomments", "type", "species", "breed1", "breed2", 
-    "color", "sex", "neutered", "weight"
+    "color", "sex", "neutered", "weight", "datebroughtin"
     """
     l = dbo.locale
     fields = get_onlineformincoming_detail(dbo, collationid)
@@ -1501,6 +1501,7 @@ def create_animal(dbo: Database, username: str, collationid: int, broughtinby: i
         if f.FIELDNAME == "size": d["size"] = str(guess_size(dbo, f.VALUE))
         if f.FIELDNAME == "neutered" and (f.VALUE == "Yes" or f.VALUE == "on"): d["neutered"] = "on"
         if f.FIELDNAME == "weight" and asm3.utils.is_numeric(f.VALUE): d["weight"] = f.VALUE
+        if f.FIELDNAME == "datebroughtin": d["datebroughtin"] = f.VALUE
         if f.FIELDNAME.startswith("additional"): d[f.FIELDNAME] = f.VALUE
     # If the form has a breed, but no species, use the species from that breed
     # For wildlife rescues, breed might be the thing people recognise over species (eg: corvid vs crow, magpie)


### PR DESCRIPTION
Fixes #1953

## Changes
- Added 'datebroughtin' to the list of recognized form fields (FORM_FIELDS)
- Updated the create_animal function to map the 'datebroughtin' form field to the animal dictionary
- Updated the function docstring to document support for the new field

## Why
This allows shelters to capture when animals are brought in via online forms. The form can now include a 'datebroughtin' field which will be properly imported and set on the animal record's DateBroughtIn field.

## How it works
1. A shelter creates an online form with a date field named 'datebroughtin'
2. When the form is submitted, the datebroughtin value is mapped in the create_animal function
3. The value is passed to insert_animal_from_form which already supports datebroughtin
4. The datetime parsing in insert_animal_from_form handles both date and optional time components

## Testing
- The existing test_create_animal test verifies animal creation works
- The insert_animal_from_form function already has validation for datebroughtin (future limit checks, etc.)
- The implementation follows the existing pattern used for other date fields (dateofbirth) and leverages existing validation in the insert_animal_from_form function.