### PR TITLE
Online form: create logs

### DIFF
--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -349,6 +349,7 @@ DEFAULTS = {
     "MoveAdoptGeneratePaperwork": "Yes",
     "MoveAdoptDonationsEnabled": "No",
     "JSWindowPrint": "Yes",
+    "OnlineFormDefaultLogType": "3",
     "OnlineFormSpamHoneyTrap": "Yes",
     "OnlineFormSpamUACheck": "No",
     "OnlineFormSpamFirstnameMixCase": "Yes",
@@ -1033,6 +1034,9 @@ def default_media_notes_from_file(dbo: Database) -> bool:
 
 def default_nonsheltertype(dbo: Database) -> int:
     return cint(dbo, "AFNonShelterType", 40)
+
+def default_onlineformlogtype(dbo: Database) -> int:
+    return cint(dbo, "OnlineFormDefaultLogType", 3)
 
 def default_payment_method(dbo: Database) -> int:
     return cint(dbo, "AFDefaultPaymentMethod", int(DEFAULTS["AFDefaultPaymentMethod"]))

--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -1029,14 +1029,14 @@ def default_location(dbo: Database) -> int:
 def default_log_filter(dbo: Database) -> int:
     return cint(dbo, "AFDefaultLogFilter", 0)
 
+def default_log_type(dbo: Database) -> int:
+    return cint(dbo, "AFDefaultLogType", 0)
+
 def default_media_notes_from_file(dbo: Database) -> bool:
     return cboolean(dbo, "DefaultMediaNotesFromFile", DEFAULTS["DefaultMediaNotesFromFile"] == "Yes")
 
 def default_nonsheltertype(dbo: Database) -> int:
     return cint(dbo, "AFNonShelterType", 40)
-
-def default_onlineformlogtype(dbo: Database) -> int:
-    return cint(dbo, "OnlineFormDefaultLogType", 3)
 
 def default_payment_method(dbo: Database) -> int:
     return cint(dbo, "AFDefaultPaymentMethod", int(DEFAULTS["AFDefaultPaymentMethod"]))

--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -349,7 +349,6 @@ DEFAULTS = {
     "MoveAdoptGeneratePaperwork": "Yes",
     "MoveAdoptDonationsEnabled": "No",
     "JSWindowPrint": "Yes",
-    "OnlineFormDefaultLogType": "3",
     "OnlineFormSpamHoneyTrap": "Yes",
     "OnlineFormSpamUACheck": "No",
     "OnlineFormSpamFirstnameMixCase": "Yes",

--- a/src/asm3/dbupdates/35121.py
+++ b/src/asm3/dbupdates/35121.py
@@ -1,0 +1,8 @@
+from asm3.dbupdate import add_column, add_index, execute
+add_column(dbo, "onlineform", "LogTypeID", dbo.type_integer)
+add_index(dbo, "onlineform_LogTypeID", "onlineform", "LogTypeID")
+execute(dbo, "UPDATE onlineform SET LogTypeID = 0")
+
+add_column(dbo, "onlineformincoming", "FormID", dbo.type_integer)
+add_index(dbo, "onlineformincoming_FormID", "onlineformincoming", "FormID")
+execute(dbo, "UPDATE onlineformincoming SET FormID = 0")

--- a/src/asm3/dbupdates/35121.py
+++ b/src/asm3/dbupdates/35121.py
@@ -1,8 +1,0 @@
-from asm3.dbupdate import add_column, add_index, execute
-add_column(dbo, "onlineform", "LogTypeID", dbo.type_integer)
-add_index(dbo, "onlineform_LogTypeID", "onlineform", "LogTypeID")
-execute(dbo, "UPDATE onlineform SET LogTypeID = 0")
-
-add_column(dbo, "onlineformincoming", "FormID", dbo.type_integer)
-add_index(dbo, "onlineformincoming_FormID", "onlineformincoming", "FormID")
-execute(dbo, "UPDATE onlineformincoming SET FormID = 0")

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -95,7 +95,7 @@ SPAMBOT_TXT = 'a_emailaddress'
 SYSTEM_FIELDS = [ "useragent", "ipaddress", "retainfor", "formreceived", "mergeperson", "processed" ]
 
 # Hidden fields that are sent with forms, but are not part of the form data
-IGNORE_FIELDS = [ SPAMBOT_TXT, "formname", "flags", "redirect", "account", "filechooser", "method", "mediaflags", "submitterreplyto" ]
+IGNORE_FIELDS = [ SPAMBOT_TXT, "formname", "flags", "redirect", "account", "filechooser", "method", "mediaflags", "submitterreplyto", "formid" ]
 
 # Online field names that we recognise and will attempt to map to
 # known fields when importing from submitted forms
@@ -192,6 +192,7 @@ def get_onlineform_html(dbo: Database, formid: int, completedocument: bool = Tru
     h.append('<input type="hidden" name="flags" value="%s" />' % form.SETOWNERFLAGS)
     h.append('<input type="hidden" name="mediaflags" value="%s" />' % form.SETMEDIAFLAGS)
     h.append('<input type="hidden" name="formname" value="%s" />' % asm3.html.escape(form.NAME))
+    h.append('<input type="hidden" name="formid" value="%s" />' % asm3.html.escape(form.ID))
     h.append('<input type="hidden" name="submitterreplyto" value="%s" />' % asm3.html.escape(form.SUBMITTERREPLYADDRESS))
     h.append('<table class="asm-onlineform-table">')
     shelteranimals = None
@@ -721,6 +722,7 @@ def insert_onlineform_from_form(dbo: Database, username: str, post: PostedData) 
         "Name":                 post["name"],
         "RedirectUrlAfterPOST": post["redirect"],
         "AutoProcess":          post.integer("autoprocess"),
+        "LogTypeID":            post.integer("logtypeid"),
         "RetainFor":            post.integer("retainfor"),
         "SetOwnerFlags":        post["flags"],
         "SetMediaFlags":        post["mediaflags"],
@@ -744,6 +746,7 @@ def update_onlineform_from_form(dbo: Database, username: str, post: PostedData) 
         "Name":                 post["name"],
         "RedirectUrlAfterPOST": post["redirect"],
         "AutoProcess":          post.integer("autoprocess"),
+        "LogTypeID":            post.integer("logtypeid"),
         "RetainFor":            post.integer("retainfor"),
         "SetOwnerFlags":        post["flags"],
         "SetMediaFlags":        post["mediaflags"],
@@ -964,6 +967,7 @@ def insert_onlineformincoming_from_form(dbo: Database, post: PostedData, remotei
 
     l = dbo.locale
     formname = post["formname"]
+    formid = post.integer("formid")
     submitterreplyto = post["submitterreplyto"]
     posteddate = dbo.now()
     flags = post["flags"]
@@ -1045,6 +1049,7 @@ def insert_onlineformincoming_from_form(dbo: Database, post: PostedData, remotei
                 dbo.insert("onlineformincoming", {
                     "CollationID":      collationid,
                     "FormName":         formname,
+                    "FormID":           formid,
                     "PostedDate":       posteddate,
                     "Flags":            flags,
                     "MediaFlags":       mediaflags,
@@ -1407,6 +1412,10 @@ def attach_form(dbo: Database, username: str, linktype: int, linkid: int, collat
                 if linktype == 0:
                     d["excludefrompublish"] = "1" # auto exclude images for animals to prevent them going to adoption websites
                 asm3.media.attach_file_from_form(dbo, username, linktype, linkid, asm3.media.MEDIASOURCE_ONLINEFORM, asm3.utils.PostedData(d, dbo.locale))
+    if linktype == asm3.log.ANIMAL:
+        logtypeid = dbo.query_int("SELECT f.LogTypeID FROM onlineformincoming i INNER JOIN onlineform f ON i.FormID = f.ID WHERE i.CollationID = ? LIMIT 1",  (collationid,))
+        if logtypeid:
+            log_animal_form(dbo, username, linkid, logtypeid, collationid)
 
 def attach_animalbyname(dbo: Database, username: str, collationid: int, attachmedia: bool = True) -> Tuple[int, int, str]:
     """
@@ -1958,3 +1967,18 @@ def auto_remove_old_incoming_forms(dbo: Database) -> None:
     for r in rows:
         delete_onlineformincoming(dbo, "system", r.COLLATIONID)
     asm3.al.debug("removed %s incoming forms older than %s days" % (len(rows), removeafter), "onlineform.auto_remove_old_incoming_forms", dbo)
+
+def log_animal_form(dbo: Database, username: str, animalid: int, logtypeid: int, collationid: int):
+    logcontent = []
+    fields = get_onlineformincoming_detail(dbo, collationid)
+    for f in fields:
+        if f.FIELDNAME not in SYSTEM_FIELDS:
+            logcontent.append(f"{f.FIELDNAME}={f.VALUE}")
+    data = {
+        "type":     logtypeid,
+        "logdate":  asm3.i18n.format_date(asm3.i18n.today()),
+        "logtime":  asm3.i18n.format_time(asm3.i18n.now()),
+        "entry":    ", ".join(logcontent)
+    }
+    logpost = asm3.utils.PostedData(data, dbo.locale)
+    asm3.log.insert_log_from_form(dbo, username, asm3.log.ANIMAL, animalid, logpost)

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -92,7 +92,7 @@ AP_CREATEANIMAL_NONSHELTER = 11
 SPAMBOT_TXT = 'a_emailaddress'
 
 # Fields that are added to forms by the system and are not user enterable
-SYSTEM_FIELDS = [ "useragent", "ipaddress", "retainfor", "formreceived", "mergeperson", "processed", "logtype" ]
+SYSTEM_FIELDS = [ "useragent", "ipaddress", "retainfor", "formreceived", "mergeperson", "processed" ]
 
 # Hidden fields that are sent with forms, but are not part of the form data
 IGNORE_FIELDS = [ SPAMBOT_TXT, "formname", "flags", "redirect", "account", "filechooser", "method", "mediaflags", "submitterreplyto" ]
@@ -1965,15 +1965,15 @@ def create_animal_log(dbo: Database, username: str, collationid: int):
     animalname, dummy, dumy = get_onlineformincoming_animalperson(dbo, collationid)
     if animalname:
         sheltercode = animalname.split("::")[1]
-        animalid = dbo.query_int("SELECT ID FROM animal WHERE ShelterCode = '%s'" % sheltercode)
+        animalid = dbo.query_int("SELECT ID FROM animal WHERE ShelterCode = ?", [sheltercode])
     logcontent = []
     fields = get_onlineformincoming_detail(dbo, collationid)
     for f in fields:
-        if f.FIELDNAME not in SYSTEM_FIELDS:
+        if f.FIELDNAME != "logtype" and f.FIELDNAME not in SYSTEM_FIELDS:
             logcontent.append(f"{f.FIELDNAME}={f.VALUE}")
         if not logtypeid and f.FIELDNAME == "logtype":
             logtypename = f.VALUE
-            logtypeid = dbo.query_int("SELECT ID FROM logtype WHERE LogTypeName = '%s'" % logtypename)
+            logtypeid = dbo.query_int("SELECT ID FROM logtype WHERE LogTypeName = ?", [logtypename])
     if not logtypeid:
         logtypeid = asm3.configuration.default_onlineformlogtype(dbo)
     if animalid:

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -101,7 +101,7 @@ IGNORE_FIELDS = [ SPAMBOT_TXT, "formname", "flags", "redirect", "account", "file
 # Online field names that we recognise and will attempt to map to
 # known fields when importing from submitted forms
 FORM_FIELDS = [
-    "emailsubmissionto",
+    "emailsubmissionto", "logtype", 
     "title", "initials", "title2", "initials2", 
     "firstname", "forenames", "surname", "lastname", "address",
     "firstname2", "forenames2", "lastname2", "surname2",
@@ -1965,13 +1965,13 @@ def auto_remove_old_incoming_forms(dbo: Database) -> None:
 def create_animal_log(dbo: Database, username: str, collationid: int):
     logtypeid = 0
     animalid = 0
-    animalname, dummy, dumy = get_onlineformincoming_animalperson(dbo, collationid)
+    animalname, dummy, dummy = get_onlineformincoming_animalperson(dbo, collationid)
     if animalname:
         animalid = get_animal_id_from_field(dbo, animalname)
     logcontent = []
     fields = get_onlineformincoming_detail(dbo, collationid)
     for f in fields:
-        if f.FIELDNAME != "logtype" and f.FIELDNAME not in SYSTEM_FIELDS:
+        if f.FIELDNAME != "logtype" and f.FIELDNAME != "" and f.FIELDNAME not in SYSTEM_FIELDS and not f.FIELDNAME.startswith("animalname") and not f.FIELDNAME.startswith("reserveanimalname"):
             logcontent.append(f"{f.FIELDNAME}={f.VALUE}")
         if not logtypeid and f.FIELDNAME == "logtype":
             logtypename = f.VALUE

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -87,6 +87,7 @@ AP_CREATEWAITINGLIST = 8
 AP_ATTACHANIMAL_CREATEPERSON = 9 
 AP_CREATEANIMAL_BROUGHTIN = 10
 AP_CREATEANIMAL_NONSHELTER = 11
+AP_CREATEANIMALLOG = 12
 
 # The name of an extra text field inserted to trap spambots
 SPAMBOT_TXT = 'a_emailaddress'
@@ -1247,6 +1248,8 @@ def insert_onlineformincoming_from_form(dbo: Database, post: PostedData, remotei
             create_transport(dbo, "autoprocess", collationid)
         elif formdef.autoprocess == AP_CREATEWAITINGLIST:
             create_waitinglist(dbo, "autoprocess", collationid)
+        elif formdef.autoprocess == AP_CREATEANIMALLOG:
+            create_animal_log(dbo, "autoprocess", collationid)
         # We only get here if there were no issues processing the form and it's safe to delete it
         delete_onlineformincoming(dbo, "autoprocess", collationid)
     except asm3.utils.ASMValidationError as verr:

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -1976,14 +1976,8 @@ def create_animal_log(dbo: Database, username: str, collationid: int):
     if not logtypeid:
         logtypeid = asm3.configuration.default_log_type(dbo)
     if animalid:
-        data = {
-            "type":     logtypeid,
-            "logdate":  asm3.i18n.format_date(asm3.i18n.today()),
-            "logtime":  asm3.i18n.format_time(asm3.i18n.now()),
-            "entry":    ", ".join(logcontent)
-        }
-        logpost = asm3.utils.PostedData(data, dbo.locale)
-        asm3.log.insert_log_from_form(dbo, username, asm3.log.ANIMAL, animalid, logpost)
+        logtext = ", ".join(logcontent)
+        asm3.log.add_log(dbo, username, asm3.log.ANIMAL, animalid, logtypeid, logtext)
     else:
         raise asm3.utils.ASMValidationError(asm3.i18n._("Unable to match to an animal record (need animalname).", dbo.locale))
     return (collationid, animalid, animalname, 1)

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -92,10 +92,10 @@ AP_CREATEANIMAL_NONSHELTER = 11
 SPAMBOT_TXT = 'a_emailaddress'
 
 # Fields that are added to forms by the system and are not user enterable
-SYSTEM_FIELDS = [ "useragent", "ipaddress", "retainfor", "formreceived", "mergeperson", "processed" ]
+SYSTEM_FIELDS = [ "useragent", "ipaddress", "retainfor", "formreceived", "mergeperson", "processed", "logtype" ]
 
 # Hidden fields that are sent with forms, but are not part of the form data
-IGNORE_FIELDS = [ SPAMBOT_TXT, "formname", "flags", "redirect", "account", "filechooser", "method", "mediaflags", "submitterreplyto", "formid" ]
+IGNORE_FIELDS = [ SPAMBOT_TXT, "formname", "flags", "redirect", "account", "filechooser", "method", "mediaflags", "submitterreplyto" ]
 
 # Online field names that we recognise and will attempt to map to
 # known fields when importing from submitted forms
@@ -192,7 +192,6 @@ def get_onlineform_html(dbo: Database, formid: int, completedocument: bool = Tru
     h.append('<input type="hidden" name="flags" value="%s" />' % form.SETOWNERFLAGS)
     h.append('<input type="hidden" name="mediaflags" value="%s" />' % form.SETMEDIAFLAGS)
     h.append('<input type="hidden" name="formname" value="%s" />' % asm3.html.escape(form.NAME))
-    h.append('<input type="hidden" name="formid" value="%s" />' % asm3.html.escape(form.ID))
     h.append('<input type="hidden" name="submitterreplyto" value="%s" />' % asm3.html.escape(form.SUBMITTERREPLYADDRESS))
     h.append('<table class="asm-onlineform-table">')
     shelteranimals = None
@@ -722,7 +721,6 @@ def insert_onlineform_from_form(dbo: Database, username: str, post: PostedData) 
         "Name":                 post["name"],
         "RedirectUrlAfterPOST": post["redirect"],
         "AutoProcess":          post.integer("autoprocess"),
-        "LogTypeID":            post.integer("logtypeid"),
         "RetainFor":            post.integer("retainfor"),
         "SetOwnerFlags":        post["flags"],
         "SetMediaFlags":        post["mediaflags"],
@@ -746,7 +744,6 @@ def update_onlineform_from_form(dbo: Database, username: str, post: PostedData) 
         "Name":                 post["name"],
         "RedirectUrlAfterPOST": post["redirect"],
         "AutoProcess":          post.integer("autoprocess"),
-        "LogTypeID":            post.integer("logtypeid"),
         "RetainFor":            post.integer("retainfor"),
         "SetOwnerFlags":        post["flags"],
         "SetMediaFlags":        post["mediaflags"],
@@ -967,7 +964,6 @@ def insert_onlineformincoming_from_form(dbo: Database, post: PostedData, remotei
 
     l = dbo.locale
     formname = post["formname"]
-    formid = post.integer("formid")
     submitterreplyto = post["submitterreplyto"]
     posteddate = dbo.now()
     flags = post["flags"]
@@ -1049,7 +1045,6 @@ def insert_onlineformincoming_from_form(dbo: Database, post: PostedData, remotei
                 dbo.insert("onlineformincoming", {
                     "CollationID":      collationid,
                     "FormName":         formname,
-                    "FormID":           formid,
                     "PostedDate":       posteddate,
                     "Flags":            flags,
                     "MediaFlags":       mediaflags,
@@ -1413,7 +1408,15 @@ def attach_form(dbo: Database, username: str, linktype: int, linkid: int, collat
                     d["excludefrompublish"] = "1" # auto exclude images for animals to prevent them going to adoption websites
                 asm3.media.attach_file_from_form(dbo, username, linktype, linkid, asm3.media.MEDIASOURCE_ONLINEFORM, asm3.utils.PostedData(d, dbo.locale))
     if linktype == asm3.log.ANIMAL:
-        logtypeid = dbo.query_int("SELECT f.LogTypeID FROM onlineformincoming i INNER JOIN onlineform f ON i.FormID = f.ID WHERE i.CollationID = ? LIMIT 1",  (collationid,))
+        fields = get_onlineformincoming_detail(dbo, collationid)
+        logtypeid = 0
+        for f in fields:
+            if f.FIELDNAME == "logtype":
+                logtypeid = dbo.query_int(
+                    "SELECT ID FROM logtype WHERE LogTypeName = ? LIMIT 1",  
+                    (f.VALUE,)
+                )
+                break
         if logtypeid:
             log_animal_form(dbo, username, linkid, logtypeid, collationid)
 

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -1974,6 +1974,8 @@ def create_animal_log(dbo: Database, username: str, collationid: int):
         if not logtypeid and f.FIELDNAME == "logtype":
             logtypename = f.VALUE
             logtypeid = dbo.query_int("SELECT ID FROM logtype WHERE LogTypeName = '%s'" % logtypename)
+    if not logtypeid:
+        logtypeid = asm3.configuration.default_onlineformlogtype(dbo)
     if animalid:
         data = {
             "type":     logtypeid,

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -1964,8 +1964,7 @@ def create_animal_log(dbo: Database, username: str, collationid: int):
     animalid = 0
     animalname, dummy, dumy = get_onlineformincoming_animalperson(dbo, collationid)
     if animalname:
-        sheltercode = animalname.split("::")[1]
-        animalid = dbo.query_int("SELECT ID FROM animal WHERE ShelterCode = ?", [sheltercode])
+        animalid = get_animal_id_from_field(dbo, animalname)
     logcontent = []
     fields = get_onlineformincoming_detail(dbo, collationid)
     for f in fields:
@@ -1975,7 +1974,7 @@ def create_animal_log(dbo: Database, username: str, collationid: int):
             logtypename = f.VALUE
             logtypeid = dbo.query_int("SELECT ID FROM logtype WHERE LogTypeName = ?", [logtypename])
     if not logtypeid:
-        logtypeid = asm3.configuration.default_onlineformlogtype(dbo)
+        logtypeid = asm3.configuration.default_log_type(dbo)
     if animalid:
         data = {
             "type":     logtypeid,

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -660,7 +660,7 @@ def get_onlineformincoming_html_print(dbo: Database, ids: List[int],
             h.append('<div style="page-break-before: always;"></div>')
     h.append("</body></html>")
     s = "\n".join(h)
-    if strip_bgimages: s= asm3.utils.strip_background_images(s)
+    if strip_bgimages: s = asm3.utils.strip_background_images(s)
     if strip_script: s = asm3.utils.strip_script_tags(s)
     if strip_style: s = asm3.utils.strip_style_tags(s)
     return s
@@ -1407,18 +1407,6 @@ def attach_form(dbo: Database, username: str, linktype: int, linkid: int, collat
                 if linktype == 0:
                     d["excludefrompublish"] = "1" # auto exclude images for animals to prevent them going to adoption websites
                 asm3.media.attach_file_from_form(dbo, username, linktype, linkid, asm3.media.MEDIASOURCE_ONLINEFORM, asm3.utils.PostedData(d, dbo.locale))
-    if linktype == asm3.log.ANIMAL:
-        fields = get_onlineformincoming_detail(dbo, collationid)
-        logtypeid = 0
-        for f in fields:
-            if f.FIELDNAME == "logtype":
-                logtypeid = dbo.query_int(
-                    "SELECT ID FROM logtype WHERE LogTypeName = ? LIMIT 1",  
-                    (f.VALUE,)
-                )
-                break
-        if logtypeid:
-            log_animal_form(dbo, username, linkid, logtypeid, collationid)
 
 def attach_animalbyname(dbo: Database, username: str, collationid: int, attachmedia: bool = True) -> Tuple[int, int, str]:
     """
@@ -1971,17 +1959,30 @@ def auto_remove_old_incoming_forms(dbo: Database) -> None:
         delete_onlineformincoming(dbo, "system", r.COLLATIONID)
     asm3.al.debug("removed %s incoming forms older than %s days" % (len(rows), removeafter), "onlineform.auto_remove_old_incoming_forms", dbo)
 
-def log_animal_form(dbo: Database, username: str, animalid: int, logtypeid: int, collationid: int):
+def log_animal_form(dbo: Database, username: str, collationid: int):
+    logtypeid = 0
+    animalid = 0
+    animalname, dummy, dumy = get_onlineformincoming_animalperson(dbo, collationid)
+    if animalname:
+        sheltercode = animalname.split("::")[1]
+        animalid = dbo.query_int("SELECT ID FROM animal WHERE ShelterCode = '%s'" % sheltercode)
     logcontent = []
     fields = get_onlineformincoming_detail(dbo, collationid)
     for f in fields:
         if f.FIELDNAME not in SYSTEM_FIELDS:
             logcontent.append(f"{f.FIELDNAME}={f.VALUE}")
-    data = {
-        "type":     logtypeid,
-        "logdate":  asm3.i18n.format_date(asm3.i18n.today()),
-        "logtime":  asm3.i18n.format_time(asm3.i18n.now()),
-        "entry":    ", ".join(logcontent)
-    }
-    logpost = asm3.utils.PostedData(data, dbo.locale)
-    asm3.log.insert_log_from_form(dbo, username, asm3.log.ANIMAL, animalid, logpost)
+        if not logtypeid and f.FIELDNAME == "logtype":
+            logtypename = f.VALUE
+            logtypeid = dbo.query_int("SELECT ID FROM logtype WHERE LogTypeName = '%s'" % logtypename)
+    if animalid:
+        data = {
+            "type":     logtypeid,
+            "logdate":  asm3.i18n.format_date(asm3.i18n.today()),
+            "logtime":  asm3.i18n.format_time(asm3.i18n.now()),
+            "entry":    ", ".join(logcontent)
+        }
+        logpost = asm3.utils.PostedData(data, dbo.locale)
+        asm3.log.insert_log_from_form(dbo, username, asm3.log.ANIMAL, animalid, logpost)
+    else:
+        raise asm3.utils.ASMValidationError(asm3.i18n._("Unable to match to an animal record (need animalname).", dbo.locale))
+    return (collationid, animalid, animalname, 1)

--- a/src/asm3/onlineform.py
+++ b/src/asm3/onlineform.py
@@ -1959,7 +1959,7 @@ def auto_remove_old_incoming_forms(dbo: Database) -> None:
         delete_onlineformincoming(dbo, "system", r.COLLATIONID)
     asm3.al.debug("removed %s incoming forms older than %s days" % (len(rows), removeafter), "onlineform.auto_remove_old_incoming_forms", dbo)
 
-def log_animal_form(dbo: Database, username: str, collationid: int):
+def create_animal_log(dbo: Database, username: str, collationid: int):
     logtypeid = 0
     animalid = 0
     animalname, dummy, dumy = get_onlineformincoming_animalperson(dbo, collationid)

--- a/src/main.py
+++ b/src/main.py
@@ -6537,7 +6537,6 @@ class onlineforms(JSONEndpoint):
         return {
             "rows": onlineforms,
             "flags": asm3.lookups.get_person_flags(dbo),
-            "logtypes": asm3.lookups.get_log_types(dbo),
             "mediaflags": asm3.lookups.get_media_flags(dbo),
             "header": asm3.onlineform.get_onlineform_header(dbo),
             "footer": asm3.onlineform.get_onlineform_footer(dbo)

--- a/src/main.py
+++ b/src/main.py
@@ -6537,6 +6537,7 @@ class onlineforms(JSONEndpoint):
         return {
             "rows": onlineforms,
             "flags": asm3.lookups.get_person_flags(dbo),
+            "logtypes": asm3.lookups.get_log_types(dbo),
             "mediaflags": asm3.lookups.get_media_flags(dbo),
             "header": asm3.onlineform.get_onlineform_header(dbo),
             "footer": asm3.onlineform.get_onlineform_footer(dbo)

--- a/src/main.py
+++ b/src/main.py
@@ -6368,7 +6368,7 @@ class onlineform_incoming(JSONEndpoint):
         user = "form/%s" % o.user
         rv = []
         for pid in o.post.integer_list("ids"):
-            collationid, animalid, animalname, status = asm3.onlineform.log_animal_form(o.dbo, user, pid)
+            collationid, animalid, animalname, status = asm3.onlineform.create_animal_log(o.dbo, user, pid)
             rv.append("%d|%d|%s|%s" % (collationid, animalid, animalname, status))
             if asm3.configuration.onlineform_delete_on_process(o.dbo): asm3.onlineform.delete_onlineformincoming(o.dbo, user, pid)
         return "^$".join(rv)

--- a/src/main.py
+++ b/src/main.py
@@ -6363,6 +6363,16 @@ class onlineform_incoming(JSONEndpoint):
             if asm3.configuration.onlineform_delete_on_process(o.dbo): asm3.onlineform.delete_onlineformincoming(o.dbo, user, collationid)
         return "^$".join(rv)
 
+    def post_animallog(self, o):
+        self.check(asm3.users.ADD_LOG)
+        user = "form/%s" % o.user
+        rv = []
+        for pid in o.post.integer_list("ids"):
+            collationid, animalid, animalname, status = asm3.onlineform.log_animal_form(o.dbo, user, pid)
+            rv.append("%d|%d|%s|%s" % (collationid, animalid, animalname, status))
+            if asm3.configuration.onlineform_delete_on_process(o.dbo): asm3.onlineform.delete_onlineformincoming(o.dbo, user, pid)
+        return "^$".join(rv)
+
     def post_animalbroughtin(self, o):
         self.check(asm3.users.ADD_ANIMAL)
         self.check(asm3.users.ADD_PERSON)

--- a/src/static/js/onlineform_incoming.js
+++ b/src/static/js/onlineform_incoming.js
@@ -155,6 +155,8 @@ $(function() {
                         + '" href="#">' + html.icon("animal-add") + ' ' + _("Animal (non-shelter with owner)") + '</a></li>',
                     '<li id="button-animalbroughtin" class="asm-menu-item"><a '
                         + '" href="#">' + html.icon("animal-add") + ' ' + _("Animal (with brought in person)") + '</a></li>',
+                    '<li id="button-animallog" class="asm-menu-item"><a '
+                        + '" href="#">' + html.icon("log") + ' ' + _("Animal Log") + '</a></li>',
                     '<li id="button-equipmentloan" class="asm-menu-item"><a '
                         + '" href="#">' + html.icon("traploan") + ' ' + _("Equipment Loan") + '</a></li>',
                     '<li id="button-person" class="asm-menu-item"><a '
@@ -205,6 +207,10 @@ $(function() {
             });
             $("#button-animalnonshelter").click(function() {
                 onlineform_incoming.create_record("animalnonshelter", "animal");
+                return false;
+            });
+            $("#button-animallog").click(function() {
+                onlineform_incoming.create_animal_log();
                 return false;
             });
             $("#button-equipmentloan").click(function() {
@@ -368,6 +374,39 @@ $(function() {
                  hide: dlgfx.delete_hide,
                  buttons: ab
             });
+        },
+
+        /**
+         * Make an AJAX post to create an animal log.
+         */
+        create_animal_log: async function() {
+            $("#button-attach").asmmenu("hide_all");
+            header.hide_error();
+            header.show_loading(_("Creating..."));
+            let table = onlineform_incoming.table, buttons = onlineform_incoming.buttons, ids = tableform.table_ids(table);
+            try {
+                let result = await common.ajax_post("onlineform_incoming", "mode=animallog&ids=" + ids);
+                let selrows = tableform.table_selected_rows(table);
+                $.each(selrows, function(i, v) {
+                    $.each(result.split("^$"), function(ir, vr) {
+                        let [collationid, linkid, display, status] = vr.split("|");
+                        if (collationid == v.COLLATIONID) {
+                            v.LINK = '<a target="_blank" href="animal_log?id=' + linkid + '">' + display + '</a>';
+                            if (status && status == 1) {
+                                v.LINK += " " + html.icon("copy", _("Updated existing record"));
+                            }
+                            if (status && status == 2) {
+                                v.LINK += " " + html.icon("warning", _("This person has been banned from adopting animals."));
+                            }
+                        }
+                    });
+                });
+                tableform.table_update(table);
+                tableform.table_update_buttons(table, buttons);
+            }
+            finally {
+                header.hide_loading();
+            }
         },
 
         /**

--- a/src/static/js/onlineform_incoming.js
+++ b/src/static/js/onlineform_incoming.js
@@ -391,13 +391,7 @@ $(function() {
                     $.each(result.split("^$"), function(ir, vr) {
                         let [collationid, linkid, display, status] = vr.split("|");
                         if (collationid == v.COLLATIONID) {
-                            v.LINK = '<a target="_blank" href="animal_log?id=' + linkid + '">' + display + '</a>';
-                            if (status && status == 1) {
-                                v.LINK += " " + html.icon("copy", _("Updated existing record"));
-                            }
-                            if (status && status == 2) {
-                                v.LINK += " " + html.icon("warning", _("This person has been banned from adopting animals."));
-                            }
+                            v.LINK = '<a target="_blank" href="animal_log?id=' + linkid + '">' + display + '</a> ' + html.icon("log", _("Updated existing record"));
                         }
                     });
                 });

--- a/src/static/js/onlineforms.js
+++ b/src/static/js/onlineforms.js
@@ -19,6 +19,7 @@ $(function() {
             { ID: 2, NAME: _("Create animal") },
             { ID: 10, NAME: _("Create animal and person (link via brought in)") },
             { ID: 11, NAME: _("Create animal and person (non-shelter with owner)") },
+            { ID: 12, NAME: _("Create animal log") },
             { ID: 3, NAME: _("Create person") },
             { ID: 4, NAME: _("Create lost animal") },
             { ID: 5, NAME: _("Create found animal") },

--- a/src/static/js/onlineforms.js
+++ b/src/static/js/onlineforms.js
@@ -63,6 +63,10 @@ $(function() {
                         type: "select", classes: "asm-doubleselectbox",
                         callout: _("Process submissions of this form automatically and bypass the incoming forms queue"),
                         options: { displayfield: "NAME", valuefield: "ID", rows: onlineforms.auto_process_options } },
+                    { json_field: "LOGTYPEID", post_field: "logtypeid", label: _("Log Type"), type: "select",
+                        options: { displayfield: "LOGTYPENAME", valuefield: "ID", rows: controller.logtypes, prepend: '<option value="0">' + _("None") + "</option>" },
+                        callout: _("Record the content of the form in an animal log, this only applies to animal related forms")
+                    },
                     { json_field: "RETAINFOR", post_field: "retainfor", label: _("Retain for"),
                         type: "select",
                         callout: _("Retain processed form submissions on the media tab for a number of years"),

--- a/src/static/js/onlineforms.js
+++ b/src/static/js/onlineforms.js
@@ -63,10 +63,6 @@ $(function() {
                         type: "select", classes: "asm-doubleselectbox",
                         callout: _("Process submissions of this form automatically and bypass the incoming forms queue"),
                         options: { displayfield: "NAME", valuefield: "ID", rows: onlineforms.auto_process_options } },
-                    { json_field: "LOGTYPEID", post_field: "logtypeid", label: _("Log Type"), type: "select",
-                        options: { displayfield: "LOGTYPENAME", valuefield: "ID", rows: controller.logtypes, prepend: '<option value="0">' + _("None") + "</option>" },
-                        callout: _("Record the content of the form in an animal log, this only applies to animal related forms")
-                    },
                     { json_field: "RETAINFOR", post_field: "retainfor", label: _("Retain for"),
                         type: "select",
                         callout: _("Retain processed form submissions on the media tab for a number of years"),

--- a/src/static/js/options.js
+++ b/src/static/js/options.js
@@ -898,6 +898,9 @@ $(function() {
                     ]}, 
                     { id: "tab-onlineforms", title: _("Online Forms"), fields: [
                         { id: "autoremoveforms", post_field: "AutoRemoveIncomingFormsDays", label: _("Remove incoming forms after"), type: "number", min: 1, max: 56, prelabel: "hcb", halfsize: true, xmarkup: _(" days.") }, 
+                        { id: "defaultonlineformlogtype", post_field: "OnlineFormDefaultLogType", label: _("If no logtype can be determined, use this type"), type: "select", 
+                            options: html.list_to_options(controller.logtypes, "ID", "LOGTYPENAME"), prelabel: "hcb"
+                        }, 
                         { id: "deleteonprocess", post_field: "OnlineFormDeleteOnProcess", label: _("Remove forms immediately when I process them"), type: "check", fullrow: true }, 
                         { id: "removeprocessedforms", post_field: "rc:DontRemoveProcessedForms", label: _("Remove processed forms when I leave the incoming forms screens"), type: "check", fullrow: true }, 
                         { id: "hashprocessedforms", post_field: "AutoHashProcessedForms", label: _("When storing processed forms as media, apply tamper proofing and make them read only"), type: "check", fullrow: true }, 


### PR DESCRIPTION
Some users would like the ability for online forms to create a log entry. I think this is only really useful for animals so make it contingent on an animalname field being supplied and it referencing an existing animal. There should be some way of specifying the log type in the form as well.

The log entry created should use the same format as daily obs, with field=value pairs in the string for all of the fields in the form (except for the built in ones).

One possible use for this is for fosterers recording daily obs for the animals in their care. By making a form that has the same fields as your daily obs configuration, they can enter them without having to have access to the daily obs screen or us adding fosterers as locations to daily obs (which makes no sense since it's about batching entering obs for lots of animals in one location).