### PR TITLE
Update Print Person Record

### DIFF
--- a/reports/person_print.rep
+++ b/reports/person_print.rep
@@ -2,7 +2,7 @@ Print Person Record
 ###
 Auditing
 ###
-34702/Any rev08
+35100/Any rev09
 ###
 A complete printout of a person record.
 ###
@@ -28,7 +28,7 @@ HEADER$$
 
 $$BODY
 <h2><a target="_blank" href="person?id=$PersonID">$OWNERNAME</a></h2>
-<table>
+<table class="nosort">
 <tr>
 <td>Address</td><td><b>$OWNERADDRESS</b></td><td>Home</td><td>$HOMETELEPHONE</td>
 </tr><tr>
@@ -239,9 +239,12 @@ FOOTER$$
 +++
 SUBREPORT_PersonPrintLog
 +++
-SELECT lo.*, lt.LogTypeName FROM log lo
+SELECT lo.Date, lt.LogTypeName, lo.Comments FROM log lo
 INNER JOIN logtype lt ON lt.ID = lo.LogTypeID
 WHERE lo.LinkType = 1 AND lo.LinkID = $PARENTKEY$
+UNION SELECT lm.Date, lt.LogTypeName, lm.Comments FROM logmulti lm
+INNER JOIN logtype lt ON lt.ID = lm.LogTypeID
+WHERE lm.LinkType = 1 AND ',' || lm.LinkIDs || ',' LIKE '%,$PARENTKEY$,%' 
 +++
 $$HEADER
 <table>


### PR DESCRIPTION
https://github.com/sheltermanager/asm3/issues/941 introduced a new logmulti table. The original ticket mentioned:

`A separate logmulti table would be the answer for these. As well as the log message itself, it would need columns for LogTypeID, LinkTypeID and then a comma or pipe separated list of LinkIDs.

Since these messages are in a different table, it's easy enough to UNION them for the screens, but by default reports that output logs would not include them. I'm not sure if that's an issue since it's really only people that we would normally be considering for this at the moment. Print Person Record probably should include them.`