### PR TITLE
PetFinder: Send YouTube video link

### DIFF
--- a/src/asm3/publishers/petfinder.py
+++ b/src/asm3/publishers/petfinder.py
@@ -409,12 +409,13 @@ class PetFinderPublisher(FTPPublisher):
         else:
             # Adoptable - include all available upto a max of 6 photos
             urls = self.getPhotoUrls(an.ID)
-            line.append(self.pfImageUrl(an.ID, urls, 0, cikeys)) # photo1
-            line.append(self.pfImageUrl(an.ID, urls, 1, cikeys)) # photo2
-            line.append(self.pfImageUrl(an.ID, urls, 2, cikeys)) # photo3
-            line.append(self.pfImageUrl(an.ID, urls, 3, cikeys)) # photo4
-            line.append(self.pfImageUrl(an.ID, urls, 4, cikeys)) # photo5
-            line.append(self.pfImageUrl(an.ID, urls, 5, cikeys)) # photo6
+            videolinkincluded = False
+            for a in range(0, 6):
+                url = self.pfImageUrl(an.ID, urls, 0, cikeys)
+                if url:
+                    line.append(self.pfImageUrl(an.ID, urls, 0, cikeys))
+                if an.WEBSITEVIDEOURL and not videolinkincluded and (not url or a == 5):
+                    line.append(an.WEBSITEVIDEOURL)
         # Arrival Date
         line.append(self.pfDate(an.MOSTRECENTENTRYDATE))
         # Birth Date

--- a/src/asm3/publishers/petfinder.py
+++ b/src/asm3/publishers/petfinder.py
@@ -418,12 +418,12 @@ class PetFinderPublisher(FTPPublisher):
             urls = self.getPhotoUrls(an.ID)
             videolinkincluded = False
             for a in range(0, 6):
-                url = self.pfImageUrl(an.ID, urls, 0, cikeys)
+                url = self.pfImageUrl(an.ID, urls, a, cikeys)
                 if an.WEBSITEVIDEOURL and not videolinkincluded and (not url or a == 5):
                     line.append(an.WEBSITEVIDEOURL)
                     videolinkincluded = True
                 else:
-                    line.append(self.pfImageUrl(an.ID, urls, 0, cikeys))
+                    line.append(url)
         # Arrival Date
         line.append(self.pfDate(an.MOSTRECENTENTRYDATE))
         # Birth Date

--- a/src/asm3/publishers/petfinder.py
+++ b/src/asm3/publishers/petfinder.py
@@ -408,14 +408,22 @@ class PetFinderPublisher(FTPPublisher):
             line.append("")
         else:
             # Adoptable - include all available upto a max of 6 photos
+            validvideourl = False
+            for marker in [ "youtube.com/", "youtu.be/", "vimeo.com/"]:
+                if marker in an.WEBSITEVIDEOURL:
+                    validvideourl = True
+                    break
+            if not validvideourl:
+                an.WEBSITEVIDEOURL = ""
             urls = self.getPhotoUrls(an.ID)
             videolinkincluded = False
             for a in range(0, 6):
                 url = self.pfImageUrl(an.ID, urls, 0, cikeys)
-                if url:
-                    line.append(self.pfImageUrl(an.ID, urls, 0, cikeys))
                 if an.WEBSITEVIDEOURL and not videolinkincluded and (not url or a == 5):
                     line.append(an.WEBSITEVIDEOURL)
+                    videolinkincluded = True
+                else:
+                    line.append(self.pfImageUrl(an.ID, urls, 0, cikeys))
         # Arrival Date
         line.append(self.pfDate(an.MOSTRECENTENTRYDATE))
         # Birth Date

--- a/src/asm3/publishers/petfinder.py
+++ b/src/asm3/publishers/petfinder.py
@@ -416,14 +416,12 @@ class PetFinderPublisher(FTPPublisher):
             if not validvideourl:
                 an.WEBSITEVIDEOURL = ""
             urls = self.getPhotoUrls(an.ID)
-            videolinkincluded = False
-            for a in range(0, 6):
-                url = self.pfImageUrl(an.ID, urls, a, cikeys)
-                if an.WEBSITEVIDEOURL and not videolinkincluded and (not url or a == 5):
-                    line.append(an.WEBSITEVIDEOURL)
-                    videolinkincluded = True
-                else:
-                    line.append(url)
+            line.append(self.pfImageUrl(an.ID, urls, 0, cikeys)) # photo1
+            line.append(self.pfImageUrl(an.ID, urls, 1, cikeys)) # photo2
+            line.append(self.pfImageUrl(an.ID, urls, 2, cikeys)) # photo3
+            line.append(self.pfImageUrl(an.ID, urls, 3, cikeys)) # photo4
+            line.append(self.pfImageUrl(an.ID, urls, 4, cikeys)) # photo5
+            line.append(asm3.utils.iif(validvideourl, an.WEBSITEVIDEOURL, self.pfImageUrl(an.ID, urls, 5, cikeys))) # photo 6 or preferred video
         # Arrival Date
         line.append(self.pfDate(an.MOSTRECENTENTRYDATE))
         # Birth Date


### PR DESCRIPTION
PetFinder can now accept YouTube or Vimeo URLs in the photo1-6 fields of the data file.

People have been asking for this for a long time.

We currently allow one preferred video per animal. If that preferred video media for animal is a YouTube URL link, send it in the first empty photo slot. If there isn't one, replace photo6.

This means the PetFinder limit is now 6 pieces of media rather than 6 photos.