### PR TITLE
personchoosermulti widget

### DIFF
--- a/scripts/rollup/rollup.py
+++ b/scripts/rollup/rollup.py
@@ -8,7 +8,7 @@
 import os
 
 jsfiles = [ "common.js", "common_validate.js", "common_html.js", "common_map.js", "common_widgets.js", "common_widgets_comp.js", 
-    "common_animalchooser.js","common_animalchoosermulti.js", "common_personchooser.js", "common_tableform.js", "common_barcode.js", 
+    "common_animalchooser.js","common_animalchoosermulti.js", "common_personchooser.js", "common_personchoosermulti.js", "common_tableform.js", "common_barcode.js", 
     "common_microchip.js", "header.js", "header_additional.js", "header_edit_header.js" ]
 
 exclude = [ "animal_view_adoptable.js", "document_edit.js", "onlineform_embed.js", "onlineform_extra.js", "report_toolbar.js" ]

--- a/scripts/rollup/rollup_compat.py
+++ b/scripts/rollup/rollup_compat.py
@@ -12,7 +12,7 @@ def readfile_print(fname):
         print(f.read())
 
 jsfiles = [ "common.js", "common_validate.js", "common_html.js", "common_map.js", "common_widgets.js", "common_widgets_comp.js", 
-    "common_animalchooser.js", "common_animalchoosermulti.js", "common_personchooser.js", "common_tableform.js", "common_barcode.js", 
+    "common_animalchooser.js", "common_animalchoosermulti.js", "common_personchooser.js", "common_personchoosermulti.js", "common_tableform.js", "common_barcode.js", 
     "common_microchip.js", "header.js", "header_additional.js", "header_edit_header.js" ]
 
 exclude = [ "animal_view_adoptable.js", "document_edit.js", "onlineform_embed.js", "onlineform_extra.js", "report_toolbar.js" ]

--- a/src/asm3/html.py
+++ b/src/asm3/html.py
@@ -67,7 +67,7 @@ def asm_script_tags(path: str) -> str:
     Returns separate script tags for all ASM javascript files.
     """
     jsfiles = [ "common.js", "common_validate.js", "common_html.js", "common_map.js", "common_widgets.js", "common_widgets_comp.js", 
-        "common_animalchooser.js", "common_animalchoosermulti.js", "common_personchooser.js", "common_tableform.js", "common_barcode.js", 
+        "common_animalchooser.js", "common_animalchoosermulti.js", "common_personchooser.js", "common_personchoosermulti.js", "common_tableform.js", "common_barcode.js", 
         "common_microchip.js", "header.js", "header_additional.js", "header_edit_header.js" ]
     # Read our available js files and append them to this list, not including ones
     # we've explicitly added above (since they are in correct load order)

--- a/src/main.py
+++ b/src/main.py
@@ -7104,6 +7104,14 @@ class person_embed(ASMEndpoint):
         asm3.al.debug("find '%s' got %d rows" % (self.query(), len(rows)), "main.person_embed", o.dbo)
         return asm3.utils.json(rows)
 
+    def post_multiselect(self, o):
+        self.content_type("application/json")
+        dbo = o.dbo
+        rows = asm3.person.get_person_find_simple(dbo, "", classfilter="all", limit=asm3.configuration.record_search_limit(dbo))
+        flags = asm3.lookups.get_person_flags(dbo)
+        rv = { "rows": rows, "flags": flags }
+        return asm3.utils.json(rv)
+
     def post_id(self, o):
         self.check(asm3.users.VIEW_PERSON)
         self.content_type("application/json")
@@ -7124,14 +7132,17 @@ class person_embed(ASMEndpoint):
         self.content_type("application/json")
         self.cache_control(120)
         dbo = o.dbo
-        pid = o.post.integer("id")
-        p = asm3.person.get_person_embedded(dbo, pid)
-        if not p:
-            asm3.al.error("get person by id %d found no records." % pid, "main.person_embed", dbo)
-            raise web.notfound()
-        else:
-            asm3.person.embellish_adoption_warnings(dbo, p)
-            return asm3.utils.json((p,))
+        pids = o.post["ids"]
+        rows = []
+        for pid in [int(pid) for pid in pids.split(",")]:
+            p = asm3.person.get_person_embedded(dbo, pid)
+            if not p:
+                asm3.al.error("get person by id %d found no records." % pid, "main.person_embed", dbo)
+                raise web.notfound()
+            else:
+                asm3.person.embellish_adoption_warnings(dbo, p)
+                rows.append(p)
+        return asm3.utils.json(rows)
 
     def post_postcodelookup(self, o):
         self.content_type("application/json")

--- a/src/main.py
+++ b/src/main.py
@@ -7107,9 +7107,8 @@ class person_embed(ASMEndpoint):
     def post_multiselect(self, o):
         self.content_type("application/json")
         dbo = o.dbo
-        rows = asm3.person.get_person_find_simple(dbo, "", classfilter="all", limit=asm3.configuration.record_search_limit(dbo))
         flags = asm3.lookups.get_person_flags(dbo)
-        rv = { "rows": rows, "flags": flags }
+        rv = { "rows": [], "flags": flags }
         return asm3.utils.json(rv)
 
     def post_id(self, o):
@@ -7132,17 +7131,14 @@ class person_embed(ASMEndpoint):
         self.content_type("application/json")
         self.cache_control(120)
         dbo = o.dbo
-        pids = o.post["ids"]
-        rows = []
-        for pid in [int(pid) for pid in pids.split(",")]:
-            p = asm3.person.get_person_embedded(dbo, pid)
-            if not p:
-                asm3.al.error("get person by id %d found no records." % pid, "main.person_embed", dbo)
-                raise web.notfound()
-            else:
-                asm3.person.embellish_adoption_warnings(dbo, p)
-                rows.append(p)
-        return asm3.utils.json(rows)
+        pid = o.post.integer("id")
+        p = asm3.person.get_person_embedded(dbo, pid)
+        if not p:
+            asm3.al.error("get person by id %d found no records." % pid, "main.person_embed", dbo)
+            raise web.notfound()
+        else:
+            asm3.person.embellish_adoption_warnings(dbo, p)
+            return asm3.utils.json((p,))
 
     def post_postcodelookup(self, o):
         self.content_type("application/json")

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -369,6 +369,24 @@ select:disabled, input:disabled, textarea:disabled {
     opacity: 1.0; 
     zoom: 1;
 }
+.asm-personchoosermulti-filter {
+    padding-top: 5px;
+    display: inline-block;
+    vertical-align: top;
+}
+.asm-personchoosermulti-filter .asmSelect {
+    width: 150px;
+}
+/* .asm-personchoosermulti-result {
+    display: inline-block;
+    text-align: center;
+    opacity: 0.5; 
+    zoom: 1;
+} */
+.asm-personchoosermulti-selected {
+    opacity: 1.0; 
+    zoom: 1;
+}
 
 /** SEARCH SCREENS ================= */
 .asm-search-selector {

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -377,12 +377,6 @@ select:disabled, input:disabled, textarea:disabled {
 .asm-personchoosermulti-filter .asmSelect {
     width: 150px;
 }
-/* .asm-personchoosermulti-result {
-    display: inline-block;
-    text-align: center;
-    opacity: 0.5; 
-    zoom: 1;
-} */
 .asm-personchoosermulti-selected {
     opacity: 1.0; 
     zoom: 1;

--- a/src/static/js/common.js
+++ b/src/static/js/common.js
@@ -1082,6 +1082,7 @@ const common = {
         $(".asm-animalchooser").animalchooser();
         $(".asm-animalchoosermulti").animalchoosermulti();
         $(".asm-personchooser").personchooser();
+        $(".asm-personchoosermulti").personchoosermulti();
         $(".asm-callout").callout();
         $(".asm-datebox").date();
         $(".asm-alphanumberbox").alphanumber();

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -316,12 +316,6 @@ $.fn.personchoosermulti = asm_widget({
                     let rowid = checkbox.attr("data");
                     $.each(o.rows, function(i, r) {
                         if (r.ID == rowid) {
-                            // let rowpresent = false;
-                            // $.each(o.selectedrows, function(i, v) {
-                            //     if (v.ID == r.ID) {
-                            //         rowpresent = true;
-                            //     }
-                            // });
                             let rowpresent = common.get_row(o.selectedrows, r.ID) != null;
                             if (checkbox.prop("checked") && !rowpresent) {
                                 o.selectedrows.push(r);

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -187,20 +187,33 @@ $.fn.personchoosermulti = asm_widget({
      */
     select: function(t) {
         let self = this, o = t.data("o"), selval = [];
+        let summaryfloor = 5;
         o.display.html("");
-        let h = [
-            '<div class="personchoosermulti-summary">',
-            '<span class="personchooser-summaryexpander ui-icon ui-icon-triangle-1-e" data="0"></span>',
-            '<b>' + _("{0} selected").replace("{0}", o.selectedrows.length) + '</b>',
-            '</div>',
-            '<div class="personchoosermulti-details" style="display: none;">'
-        ];
-        $.each(o.selectedrows, function(i, p) {
-            selval.push(p.ID);
-            h.push("<a class=\"asm-embed-name\" href=\"person?id=" + p.ID + "\">" + p.OWNERNAME + "</a><br />");
-        });
-        h.push('</div>');
-        o.display.append(h.join("\n"));
+        let h = []
+        if (o.selectedrows.length > 0) {
+            if (o.selectedrows.length > summaryfloor) {
+                h = [
+                    '<div class="personchoosermulti-summary">',
+                    '<span class="personchooser-summaryexpander ui-icon ui-icon-triangle-1-e" data="0"></span>',
+                    '<b>' + _("{0} selected").replace("{0}", o.selectedrows.length) + '</b>',
+                    '</div>'
+                ];
+            }
+            h.push('<div class="personchoosermulti-details" style="display: none;">');
+            $.each(o.selectedrows, function(i, p) {
+                selval.push(p.ID);
+                h.push('<a class="asm-embed-name" href="person?id=' + p.ID + '">' + p.OWNERNAME + '</a><br />');
+            });
+            h.push('</div>');
+            if (o.selectedrows.length > summaryfloor) {
+                h.push('</div>');
+            }
+        }
+        let outputhtml = h.join("\n");
+        o.display.html(outputhtml);
+        if (o.selectedrows.length <= summaryfloor) {
+            o.display.find(".personchoosermulti-details").show();
+        }
         t.val(selval.join(","));
         t.trigger("change", [ t.val() ]);
         o.dialog.dialog("close");

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -316,15 +316,17 @@ $.fn.personchoosermulti = asm_widget({
                     let rowid = checkbox.attr("data");
                     $.each(o.rows, function(i, r) {
                         if (r.ID == rowid) {
-                            let rowpresent = false;
-                            $.each(o.selectedrows, function(i, v) {
-                                if (v.ID == r.ID) {
-                                    rowpresent = true;
-                                }
-                            });
+                            // let rowpresent = false;
+                            // $.each(o.selectedrows, function(i, v) {
+                            //     if (v.ID == r.ID) {
+                            //         rowpresent = true;
+                            //     }
+                            // });
+                            let rowpresent = common.get_row(o.selectedrows, r.ID) != null;
                             if (checkbox.prop("checked") && !rowpresent) {
                                 o.selectedrows.push(r);
                             } else if (!checkbox.prop("checked") && rowpresent) {
+                                // Iterating through a copy of selected rows so changes can be made
                                 $.each([...o.selectedrows], function(c, s) {
                                     if (r.ID == s.ID) {
                                         o.selectedrows.splice(c, 1);

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -1,0 +1,321 @@
+/*global $, console, jQuery */
+/*global asm, asm_widget, common, config, dlgfx, format, html, header, log, validate, _, escape, unescape */
+
+"use strict";
+
+/**
+ * Multiple person chooser widget. To create one, use a hidden input
+ * with a class of asm-personchoosermulti for bind_widgets to autoload
+ *
+ * <input id="person" class="asm-personchoosermulti" data="boundfield" type="hidden" value="commaseparatedids" />
+ * 
+ * $(".asm-personchoosermulti").personchoosermulti(); // (bind_widgets does this automatically)
+ *
+ * events: select (after selectbyids is complete)
+ *         change (after user has clicked select button)
+ *         cleared (after user clicks the clear button)
+ */
+$.fn.personchoosermulti = asm_widget({
+
+    _create: function(t) {
+        
+        let self = this;
+
+        let h = [
+            '<div class="personchoosermulti asm-chooser-container">',
+            '<table style="margin-left: 0px; margin-right: 0px; width: 100%; ">',
+            '<tr>',
+            '<td class="personchoosermulti-display">',
+            '</td>',
+            '<td valign="top" style="text-align: end; white-space: nowrap">',
+            '<button type="button" class="personchoosermulti-link-find">' + _("Select people") + '</button>',
+            '<button type="button" class="personchoosermulti-link-clear">' + _("Clear") + '</button>',
+            '</td>',
+            '</tr>',
+            '</table>',
+            '<div class="personchoosermulti-find" title="' + html.title(_("Select people")) + '">',
+            '<div class="totalselected">',
+            html.info(_("{0} selected").replace("{0}", "0")),
+            '</div>',
+            '<img style="height: 16px" class="spinner" src="static/images/wait/rolling_3a87cd.svg" />',
+            '<div style="border-bottom: 1px solid #aaa; width: 100%">',
+            '<div class="asm-personchoosermulti-filter">',
+            '<a href="#" class="personchoosermulti-selectall" title="Select all"><span class="ui-icon ui-icon-check"></span></a>',
+            '</div>',
+            '<div class="asm-personchoosermulti-filter">',
+             _("Flags") + ': <select multiple="multiple" title="' + _("Filter") + '" class="personchoosermulti-flags asm-selectmulti"></select>', 
+            '</div>',
+            '</div>',
+            '<div>',
+            '<table class="personchoosermulti-results"></table>',
+            '</div>',
+            '</div>', 
+            '</div>'
+        ].join("\n");
+
+        let node = $(h);
+
+        let o = {};
+        t.data("o", o);
+        o.node = node;
+        o.dialog = node.find(".personchoosermulti-find");
+        o.display = node.find(".personchoosermulti-display");
+        o.flags = node.find(".personchoosermulti-flags");
+        o.results = node.find(".personchoosermulti-results");
+        o.loaded = false;
+
+        t.parent().append(node);
+
+        // Create the dialog
+        let acbuttons = {};
+        acbuttons[_("Select")] = function() { self.select.call(self, t); };
+        acbuttons[_("Cancel")] = function() { $(this).dialog("close"); };
+        o.dialog.dialog({
+            autoOpen: false,
+            height: common.vheight(600),
+            width: common.vwidth(875),
+            modal: true,
+            dialogClass: "dialogshadow",
+            show: dlgfx.edit_show,
+            hide: dlgfx.edit_hide,
+            buttons: acbuttons,
+            open: function() {
+                // Load person thumbs when opening the dialog if they
+                // haven't been loaded yet
+                if (!o.loaded) {
+                    self.load.call(self, t);
+                    o.loaded = true;
+                }
+            }
+        });
+
+        o.dialog.find("img").hide();
+
+        // Bind the find button
+        node.find(".personchoosermulti-link-find")
+            .button({ icons: { primary: "ui-icon-search" }, text: false })
+            .click(function() {
+                o.dialog.dialog("open");
+            });
+
+        // Bind the clear button
+        node.find(".personchoosermulti-link-clear")
+            .button({ icons: { primary: "ui-icon-trash" }, text: false })
+            .click(function() {
+                self.clear.call(self, t, true);
+            });
+    },
+
+    /**
+     * Empties the widget
+     */
+    clear: function(t, fireclearedevent = false) {
+        t.val("");
+        let o = t.data("o");
+        o.display.html("");
+        o.results.find(":checked").prop("checked", false);
+        this.update_status(t);
+        if (fireclearedevent) { t.trigger("cleared"); }
+    },
+
+    is_empty: function(t) {
+        let o = t.data("o");
+        return o.results.find(":checked").length == 0;
+    },
+
+    destroy: function(t) {
+        try {
+            let o = t.data("o");
+            o.dialog.dialog("destroy"); 
+            o.dialog.remove();
+        }
+        catch (ex) {}
+    },
+
+    /**
+     * Returns the person row with ID aid
+     */
+    get_row: function(t, aid) {
+        let rv, o = t.data("o");
+        $.each(o.rows, function(i, v) {
+            if (v.ID == aid) {
+                rv = v;
+            }
+        });
+        return rv;
+    }, 
+
+    get_rows: function(t) {
+        return t.data("o").rows;
+    }, 
+
+    get_selected_rows: function(t) {
+        let rows = [];
+        let self = this;
+        $.each(t.val().split(","), function(i, v) {
+            rows.push(self.get_row(t, v));
+        });
+        return rows;
+    },
+
+    /**
+     * Returns true if a row has idval in column fname
+     */
+    id_used: function(t, fname, idval) {
+        let rv = false, o = t.data("o");
+        $.each(o.rows, function(i, a) {
+            if (a[fname] == idval) {
+                rv = true;
+            }
+        });
+        return rv;
+    },
+
+    /**
+     * Converts the selected items into a list of ids, sets it as the
+     * element value and puts links in the display area
+     */
+    select: function(t) {
+        let self = this, o = t.data("o"), selval = [];
+        o.display.html("");
+        o.results.find(":checked").each(function() {
+            let aid = $(this).attr("data"), rec = self.get_row(t, aid);
+            selval.push(aid);
+            console.log(rec);
+            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.OWNERNAME + "</a>";
+            o.display.append(disp);
+            o.display.append("<br />");
+        });
+        t.val(selval.join(","));
+        t.trigger("change", [ t.val() ]);
+        o.dialog.dialog("close");
+    },
+
+    /**
+     * Update the visible list of people according to what's selected in the filters
+     */
+    update_filters: function(t) {
+        let o = t.data("o");
+        $.each(o.rows, function(i, a) {
+            let show = true;
+            let selflag = String(o.flags.val()).trim().split(",");
+            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap(selflag, a.ADDITIONALFLAGS.split("|"))) { show = false; }
+            console.log(show);
+            // Show/hide the result appropriately
+            o.dialog.find(".personselect[data='" + a.ID + "']").closest(".asm-personchoosermulti-result").toggle(show);
+        });
+    },
+
+    /**
+     * Updates the info strip at the top to show how many people selected
+     */
+    update_status: function(t) {
+        let o = t.data("o");
+        let c = o.results.find(":checked").length;
+        o.dialog.find(".totalselected").html(html.info(_("{0} selected").replace("{0}", c)));
+        o.results.find(".asm-personchoosermulti-selected").removeClass("asm-personchoosermulti-selected").removeClass("ui-state-highlight");
+        o.results.find(":checked").each(function() {
+            let tn = $(this);
+            tn.closest(".asm-personchoosermulti-result").addClass("asm-personchoosermulti-selected").addClass("ui-state-highlight");
+        });
+    },
+
+    /**
+     * Selects people based on a comma separated list of ids as a string
+     */
+    selectbyids: function(t, personids, ignorechange=false) {
+        let self = this, o = t.data("o");
+        if (!ignorechange) { self.clear.call(self, t); }
+        if (!personids) { return; }
+        $.each(personids.split(","), function(i, v) {
+            o.results.find("[data='" + v + "']").prop("checked", true);
+        });
+        self.update_status(t);
+        if (!ignorechange) { t.trigger("change", [personids] ); }
+    },
+
+    load: function(t) {
+        let self = this, o = t.data("o");
+        o.dialog.find("img").show();
+        let formdata = "mode=multiselect";
+        $.ajax({
+            type: "POST",
+            url:  "person_embed",
+            data: formdata,
+            dataType: "text",
+            success: function(data, textStatus, jqXHR) {
+
+                let rv = jQuery.parseJSON(data);
+                o.rows = rv.rows;
+
+                // Flags list
+                html.person_flag_options(null, rv.flags, o.flags);
+                //flags.html( html.list_to_options(rv.flags, "FLAG", "FLAG") );
+                o.flags.change();
+                o.flags.on("change", function(e) {
+                    self.update_filters(t);
+                });
+
+                // Load the list of people
+                $.each(o.rows, function(i, a) {
+                    o.results.append('<tr class="asm-personchoosermulti-result"><td><input type="checkbox" class="personselect" data="' + a.ID + '"></td><td>' + a.OWNERNAME + '</td><td>' + a.OWNERADDRESS + '</td><td>' + a.OWNERPOSTCODE + '</td></tr>');
+                });
+
+                // Delegate event handler for the checkboxes
+                o.results.off("click", "input[type='checkbox']");
+                o.results.on("click", "input[type='checkbox']", function(e) { 
+                    self.update_status(t);
+                });
+
+                // Remove the spinner
+                o.dialog.find(".spinner").hide();
+
+                // Select all toggle
+                o.dialog.find(".personchoosermulti-selectall").click(function(e) {
+                    if (!self.select_all_toggle) {
+                        self.select_all_toggle = true;
+                        o.dialog.find(".personselect:visible").prop("checked", true);
+                        self.update_status(t);
+                    }
+                    else {
+                        self.select_all_toggle = false;
+                        o.dialog.find(".personselect").prop("checked", false);
+                        self.update_status(t);
+                    }
+                    return false;
+                });
+
+                // Was there a value already set by the markup? If so, use it
+                if (t.val() != "") {
+                    self.selectbyids(t, t.val());
+                    t.trigger("select", [ t.val() ]);
+                }
+
+            },
+            error: function(jqxhr, textstatus, response) {
+                o.dialog.dialog("close");
+                o.dialog.find(".spinner").hide();
+                log.error(response);
+            }
+        });
+    },
+
+    value: function(t, newval) {
+        // Possible race condition if this function is called before load function has completed
+        let self = this;
+        if (newval === undefined) { // Value is being extracted rather than updated
+            return t.val();
+        }
+        if (!newval) { newval = ""; }
+        t.val(newval);
+        let o = t.data("o");
+        o.display.html("");
+        $.each(newval.split(","), function(i, v) {
+            let rec = self.get_row(t, parseInt(v));
+            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.CODE + " - " + rec.ANIMALNAME + "</a>";
+            o.display.append(disp);
+            o.display.append("<br />");
+        });
+        self.selectbyids(t, newval, true);
+    }
+});

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -23,33 +23,39 @@ $.fn.personchoosermulti = asm_widget({
 
         let h = [
             '<div class="personchoosermulti asm-chooser-container">',
-            '<table style="margin-left: 0px; margin-right: 0px; width: 100%; ">',
-            '<tr>',
-            '<td class="personchoosermulti-display">',
-            '</td>',
-            '<td valign="top" style="text-align: end; white-space: nowrap">',
-            '<button type="button" class="personchoosermulti-link-find">' + _("Select people") + '</button>',
-            '<button type="button" class="personchoosermulti-link-clear">' + _("Clear") + '</button>',
-            '</td>',
-            '</tr>',
-            '</table>',
-            '<div class="personchoosermulti-find" title="' + html.title(_("Select people")) + '">',
-            '<div class="totalselected">',
-            html.info(_("{0} selected").replace("{0}", "0")),
-            '</div>',
-            '<img style="height: 16px" class="spinner" src="static/images/wait/rolling_3a87cd.svg" />',
-            '<div style="border-bottom: 1px solid #aaa; width: 100%">',
-            '<div class="asm-personchoosermulti-filter">',
-            '<a href="#" class="personchoosermulti-selectall" title="Select all"><span class="ui-icon ui-icon-check"></span></a>',
-            '</div>',
-            '<div class="asm-personchoosermulti-filter">',
-             _("Flags") + ': <select multiple="multiple" title="' + _("Filter") + '" class="personchoosermulti-flags asm-selectmulti"></select>', 
-            '</div>',
-            '</div>',
-            '<div>',
-            '<table class="personchoosermulti-results"></table>',
-            '</div>',
-            '</div>', 
+                '<table style="margin-left: 0px; margin-right: 0px; width: 100%; ">',
+                    '<tr>',
+                    '<td class="personchoosermulti-display">',
+                    '</td>',
+                    '<td valign="top" style="text-align: end; white-space: nowrap">',
+                    '<button type="button" class="personchoosermulti-link-find">' + _("Select people") + '</button>',
+                    '<button type="button" class="personchoosermulti-link-clear">' + _("Clear") + '</button>',
+                    '</td>',
+                    '</tr>',
+                '</table>',
+                '<div class="personchoosermulti-find" title="' + html.title(_("Select people")) + '">',
+                    '<div class="totalselected" style="margin-bottom: 5px;">',
+                        html.info(_("{0} selected").replace("{0}", "0")),
+                    '</div>',
+                    '<div style="border-bottom: 1px solid #aaa; width: 100%;padding-bottom: 5px;">',
+                        '<div class="asm-personchoosermulti-filter">',
+                            '<a href="#" class="personchoosermulti-selectall" title="Select all"><span class="ui-icon ui-icon-check"></span></a>',
+                        '</div>',
+                        '<div style="display: inline-block;vertical-align: top;">',
+                            '<input class="asm-textbox personchoosermulti-searchinput" type="text" />',
+                            '<button class="personchoosermulti-searchbutton">' + _("Search") + '</button>',
+                            '<img style="height: 16px" class="spinner" src="static/images/wait/rolling_3a87cd.svg" />',
+                        '</div>',
+                        '<div class="personchoosermulti-flags-container" style="display: inline-block;float: right;">',
+                            '<div style="vertical-align: top;padding-top: 3px;">' + _("Flags") + ':&nbsp;</div>',
+                            '<select style="display: inline-block;" multiple="multiple" title="' + _("Filter") + '" class="personchoosermulti-flags asm-selectmulti"></select>', 
+                        '</div>',
+                        '<div style="clear: right;"></div>',
+                    '</div>',
+                    '<div>',
+                    '<table class="personchoosermulti-results asm-widget asm-table tablesorter tablesorter-default"><thead><tr><th>' + _("Name") + '</th><th>' + _("Code") + '</th><th>' + _("Address") + '</th><th>' + _("Zipcode") + '</th></thead><tbody class="personchoosermulti-results-body"></tbody></table>',
+                    '</div>',
+                '</div>', 
             '</div>'
         ].join("\n");
 
@@ -61,7 +67,7 @@ $.fn.personchoosermulti = asm_widget({
         o.dialog = node.find(".personchoosermulti-find");
         o.display = node.find(".personchoosermulti-display");
         o.flags = node.find(".personchoosermulti-flags");
-        o.results = node.find(".personchoosermulti-results");
+        o.results = node.find(".personchoosermulti-results-body");
         o.loaded = false;
 
         t.parent().append(node);
@@ -80,16 +86,16 @@ $.fn.personchoosermulti = asm_widget({
             hide: dlgfx.edit_hide,
             buttons: acbuttons,
             open: function() {
-                // Load person thumbs when opening the dialog if they
-                // haven't been loaded yet
                 if (!o.loaded) {
                     self.load.call(self, t);
+                    $(".personchoosermulti-flags-container div").css("display", "inline-block");
                     o.loaded = true;
                 }
             }
         });
 
         o.dialog.find("img").hide();
+        o.dialog.find(".personchoosermulti-searchbutton").button().css("padding", ".2em 1em").css("top", "-1px");
 
         // Bind the find button
         node.find(".personchoosermulti-link-find")
@@ -258,7 +264,7 @@ $.fn.personchoosermulti = asm_widget({
 
                 // Load the list of people
                 $.each(o.rows, function(i, a) {
-                    o.results.append('<tr class="asm-personchoosermulti-result"><td><input type="checkbox" class="personselect" data="' + a.ID + '"></td><td>' + a.OWNERNAME + '</td><td>' + a.OWNERADDRESS + '</td><td>' + a.OWNERPOSTCODE + '</td></tr>');
+                    o.results.append('<tr class="asm-personchoosermulti-result"><td><input type="checkbox" class="personselect" data="' + a.ID + '"> <a href="person?id="' + a.ID + '" target="_blank">' + a.OWNERNAME + '</a></td><td>' + a.OWNERCODE + '</td><td>' + a.OWNERADDRESS + '</td><td>' + a.OWNERPOSTCODE + ' </td></tr>');
                 });
 
                 // Delegate event handler for the checkboxes

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -46,7 +46,7 @@ $.fn.personchoosermulti = asm_widget({
                             '<button class="personchoosermulti-searchbutton">' + _("Search") + '</button>',
                             '<img style="height: 16px" class="spinner" src="static/images/wait/rolling_3a87cd.svg" />',
                         '</div>',
-                        '<div class="personchoosermulti-flags-container" style="display: inline-block;float: right;">',
+                        '<div class="personchoosermulti-flags-container" style="display: inline-block;float: right;max-width: 400px;">',
                             '<div style="vertical-align: top;padding-top: 3px;">' + _("Flags") + ':&nbsp;</div>',
                             '<select style="display: inline-block;" multiple="multiple" title="' + _("Filter") + '" class="personchoosermulti-flags asm-selectmulti"></select>', 
                         '</div>',
@@ -205,8 +205,9 @@ $.fn.personchoosermulti = asm_widget({
         $.each(o.rows, function(i, a) {
             let show = true;
             let selflag = String(o.flags.val()).trim().split(",");
-            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap(selflag, a.ADDITIONALFLAGS.split("|"))) { show = false; }
-            console.log(show);
+
+            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, a.ADDITIONALFLAGS.split("|"))) { show = false; }
+            
             // Show/hide the result appropriately
             o.dialog.find(".personselect[data='" + a.ID + "']").closest(".asm-personchoosermulti-result").toggle(show);
         });

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -69,6 +69,7 @@ $.fn.personchoosermulti = asm_widget({
         o.flags = node.find(".personchoosermulti-flags");
         o.search = node.find(".personchoosermulti-searchbutton");
         o.results = node.find(".personchoosermulti-results-body");
+        o.selectedrows = [];
         o.loaded = false;
 
         t.parent().append(node);
@@ -145,7 +146,6 @@ $.fn.personchoosermulti = asm_widget({
      */
     get_row: function(t, pid) {
         let rv, o = t.data("o");
-        console.log(o.rows);
         $.each(o.rows, function(i, v) {
             if (v.ID == pid) {
                 rv = v;
@@ -189,10 +189,8 @@ $.fn.personchoosermulti = asm_widget({
         o.display.html("");
         o.results.find(":checked").each(function() {
             let pid = $(this).attr("data");
-            console.log(pid);
             let rec = self.get_row(t, pid);
             selval.push(pid);
-            console.log(rec);
             let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.OWNERNAME + "</a>";
             o.display.append(disp);
             o.display.append("<br />");
@@ -207,7 +205,7 @@ $.fn.personchoosermulti = asm_widget({
      */
     update_filters: function(t) {
         let o = t.data("o");
-        $.each(o.rows, function(i, a) {
+        $.each(o.rows, function(i, p) {
             let show = true;
             let selflag = String(o.flags.val()).trim().split(",");
             if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, a.ADDITIONALFLAGS.split("|"))) {
@@ -215,18 +213,27 @@ $.fn.personchoosermulti = asm_widget({
             } else {
                 show = false;
                 let searchkey = o.dialog.find(".personchoosermulti-searchinput").val();
-                if (a.OWNERNAME.toLowerCase().includes(searchkey.toLowerCase())) {
+                if (p.OWNERNAME.toLowerCase().includes(searchkey.toLowerCase())) {
                     show = true;
-                } else if (a.OWNERADDRESS.toLowerCase().includes(searchkey.toLowerCase())) {
+                } else if (p.OWNERADDRESS.toLowerCase().includes(searchkey.toLowerCase())) {
                     show = true;
-                } else if (a.OWNERPOSTCODE.toLowerCase().replace(/ /g, "").includes(searchkey.toLowerCase().replace(/ /g, ""))) {
+                } else if (p.OWNERPOSTCODE.toLowerCase().replace(/ /g, "").includes(searchkey.toLowerCase().replace(/ /g, ""))) {
                     show = true;
-                } else if (a.OWNERCODE.toLowerCase() == searchkey.toLowerCase()) {
+                } else if (p.OWNERCODE.toLowerCase() == searchkey.toLowerCase()) {
                     show = true;
                 }
             }
             // Show/hide the result appropriately
-            o.dialog.find(".personselect[data='" + a.ID + "']").closest(".asm-personchoosermulti-result").toggle(show);
+            // if (show && !o.selectedrows.includes(p)) {
+            //     o.selectedrows.push(p);
+            // } else if (!show && o.selectedrows.includes(p)) {
+            //     $.each([...o.selectedrows], function(i, r) {
+            //         if (r == p) {
+            //             o.selectedrows.splice(i, 1);
+            //         }
+            //     });
+            // }
+            o.dialog.find(".personselect[data='" + p.ID + "']").closest(".asm-personchoosermulti-result").toggle(show);
         });
     },
 
@@ -235,7 +242,7 @@ $.fn.personchoosermulti = asm_widget({
      */
     update_status: function(t) {
         let o = t.data("o");
-        let c = o.results.find(":checked").length;
+        let c = o.selectedrows.length;
         o.dialog.find(".totalselected").html(html.info(_("{0} selected").replace("{0}", c)));
         o.results.find(".asm-personchoosermulti-selected").removeClass("asm-personchoosermulti-selected").removeClass("ui-state-highlight");
         o.results.find(":checked").each(function() {
@@ -274,8 +281,6 @@ $.fn.personchoosermulti = asm_widget({
 
                 // Flags list
                 html.person_flag_options(null, rv.flags, o.flags);
-                //flags.html( html.list_to_options(rv.flags, "FLAG", "FLAG") );
-                // o.flags.change();
                 o.flags.on("change", function(e) {
                     self.find.call(self, t);
                     self.update_filters(t);
@@ -284,16 +289,39 @@ $.fn.personchoosermulti = asm_widget({
                     self.find.call(self, t);
                     self.update_filters(t);
                 });
-
-                // Load the list of people
-                // $.each(o.rows, function(i, a) {
-                //     console.log(a.ID);
-                //     o.results.append('<tr class="asm-personchoosermulti-result"><td><input type="checkbox" class="personselect" data="' + a.ID + '"> <a href="person?id=' + a.ID + '" target="_blank">' + a.OWNERNAME + '</a></td><td>' + a.OWNERCODE + '</td><td>' + a.OWNERADDRESS + '</td><td>' + a.OWNERPOSTCODE + ' </td></tr>');
-                // });
+                o.results.on("change", "input", function(e) {
+                    // console.log($(e.currentTarget));
+                    // console.log(o.rows);
+                    let checkbox = $(e.currentTarget);
+                    console.log(checkbox.prop("checked"));
+                    let rowid = checkbox.attr("data");
+                    $.each(o.rows, function(i, r) {
+                        if (r.ID == rowid) {
+                            let rowpresent = false;
+                            $.each(o.selectedrows, function(i, v) {
+                                if (v.ID == r.ID) {
+                                    rowpresent = true;
+                                }
+                            });
+                            console.log("rowpresent = " + rowpresent);
+                            if (checkbox.prop("checked") && !rowpresent) {
+                                o.selectedrows.push(r);
+                            } else if (!checkbox.prop("checked") && rowpresent) {
+                                $.each([...o.selectedrows], function(c, s) {
+                                    if (r.ID == s.ID) {
+                                        o.selectedrows.splice(c, 1);
+                                    }
+                                });
+                            }
+                        }
+                    });
+                    self.update_status(t);
+                    console.log(o.selectedrows);
+                });
 
                 // Delegate event handler for the checkboxes
                 o.results.off("click", "input[type='checkbox']");
-                o.results.on("click", "input[type='checkbox']", function(e) { 
+                o.results.on("click", "input[type='checkbox']", function(e) {
                     self.update_status(t);
                 });
 
@@ -304,12 +332,12 @@ $.fn.personchoosermulti = asm_widget({
                 o.dialog.find(".personchoosermulti-selectall").click(function(e) {
                     if (!self.select_all_toggle) {
                         self.select_all_toggle = true;
-                        o.dialog.find(".personselect:visible").prop("checked", true);
+                        o.dialog.find(".personselect:visible").prop("checked", true).change();
                         self.update_status(t);
                     }
                     else {
                         self.select_all_toggle = false;
-                        o.dialog.find(".personselect").prop("checked", false);
+                        o.dialog.find(".personselect").prop("checked", false).change();
                         self.update_status(t);
                     }
                     return false;
@@ -351,7 +379,13 @@ $.fn.personchoosermulti = asm_widget({
                 o.rows = people;
                 $.each(people, function(i, p) {
                     h += "<tr class=\"asm-personchoosermulti-result\">";
-                    h += "<td><input type=\"checkbox\" class=\"personselect\" data=\"" + p.ID + "\"><a href=\"#\" data=\"" + p.ID + "\">" + p.OWNERNAME + "</a></td>";
+                    h += "<td><input type=\"checkbox\" class=\"personselect\" data=\"" + p.ID + "\"";
+                    $.each(o.selectedrows, function(i, r) {
+                        if (r.ID == p.ID) {
+                            h += " checked";
+                        }
+                    });
+                    h += "><a href=\"/person?id=" + p.ID + "\" data=\"" + p.ID + "\">" + p.OWNERNAME + "</a></td>";
                     h += "<td>" + p.OWNERCODE + "</td>";
                     h += "<td>" + p.OWNERADDRESS + "</td>";
                     h += "<td>" + p.OWNERPOSTCODE + "</td>";
@@ -413,7 +447,7 @@ $.fn.personchoosermulti = asm_widget({
         o.display.html("");
         $.each(newval.split(","), function(i, v) {
             let rec = self.get_row(t, parseInt(v));
-            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.CODE + " - " + rec.ANIMALNAME + "</a>";
+            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.OWNERNAME + "</a>";
             o.display.append(disp);
             o.display.append("<br />");
         });

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -67,6 +67,7 @@ $.fn.personchoosermulti = asm_widget({
         o.dialog = node.find(".personchoosermulti-find");
         o.display = node.find(".personchoosermulti-display");
         o.flags = node.find(".personchoosermulti-flags");
+        o.search = node.find(".personchoosermulti-searchbutton");
         o.results = node.find(".personchoosermulti-results-body");
         o.loaded = false;
 
@@ -205,9 +206,14 @@ $.fn.personchoosermulti = asm_widget({
         $.each(o.rows, function(i, a) {
             let show = true;
             let selflag = String(o.flags.val()).trim().split(",");
-
-            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, a.ADDITIONALFLAGS.split("|"))) { show = false; }
-            
+            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, a.ADDITIONALFLAGS.split("|"))) {
+                show = false;
+            } else {
+                let searchkey = o.dialog.find(".personchoosermulti-searchinput").val();
+                if (!a.OWNERNAME.toLowerCase().includes(searchkey.toLowerCase())) {
+                    show = false;
+                }
+            }
             // Show/hide the result appropriately
             o.dialog.find(".personselect[data='" + a.ID + "']").closest(".asm-personchoosermulti-result").toggle(show);
         });
@@ -260,6 +266,9 @@ $.fn.personchoosermulti = asm_widget({
                 //flags.html( html.list_to_options(rv.flags, "FLAG", "FLAG") );
                 o.flags.change();
                 o.flags.on("change", function(e) {
+                    self.update_filters(t);
+                });
+                o.search.on("click", function(e) {
                     self.update_filters(t);
                 });
 

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -188,12 +188,19 @@ $.fn.personchoosermulti = asm_widget({
     select: function(t) {
         let self = this, o = t.data("o"), selval = [];
         o.display.html("");
+        let h = [
+            '<div class="personchoosermulti-summary">',
+            '<span class="personchooser-summaryexpander ui-icon ui-icon-triangle-1-e" data="0"></span>',
+            '<b>' + _("{0} selected").replace("{0}", o.selectedrows.length) + '</b>',
+            '</div>',
+            '<div class="personchoosermulti-details" style="display: none;">'
+        ];
         $.each(o.selectedrows, function(i, p) {
             selval.push(p.ID);
-            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + p.ID + "\">" + p.OWNERNAME + "</a>";
-            o.display.append(disp);
-            o.display.append("<br />");
+            h.push("<a class=\"asm-embed-name\" href=\"person?id=" + p.ID + "\">" + p.OWNERNAME + "</a><br />");
         });
+        h.push('</div>');
+        o.display.append(h.join("\n"));
         t.val(selval.join(","));
         t.trigger("change", [ t.val() ]);
         o.dialog.dialog("close");
@@ -207,7 +214,7 @@ $.fn.personchoosermulti = asm_widget({
         $.each(o.rows, function(i, p) {
             let show = true;
             let selflag = String(o.flags.val()).trim().split(",");
-            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, a.ADDITIONALFLAGS.split("|"))) {
+            if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, p.ADDITIONALFLAGS.split("|"))) {
                 show = false;
             } else {
                 show = false;
@@ -273,12 +280,24 @@ $.fn.personchoosermulti = asm_widget({
                 html.person_flag_options(null, rv.flags, o.flags);
                 o.flags.on("change", function(e) {
                     self.find.call(self, t);
-                    self.update_filters(t);
                 });
                 o.search.on("click", function(e) {
                     self.find.call(self, t);
-                    self.update_filters(t);
                 });
+                o.display.on("click", ".personchooser-summaryexpander", function(e) {
+                    if ($(this).attr("data") == "0") {
+                        $(this).removeClass("ui-icon-triangle-1-e");
+                        $(this).addClass("ui-icon-triangle-1-s");
+                        $(this).attr("data", "1");
+                        o.display.find(".personchoosermulti-details").fadeIn();
+                    } else {
+                        $(this).addClass("ui-icon-triangle-1-e");
+                        $(this).removeClass("ui-icon-triangle-1-s");
+                        $(this).attr("data", "0");
+                        o.display.find(".personchoosermulti-details").fadeOut();
+                    }
+                });
+                // personchooser-summaryexpander
                 o.results.on("change", "input", function(e) {
                     let checkbox = $(e.currentTarget);
                     let rowid = checkbox.attr("data");
@@ -377,37 +396,11 @@ $.fn.personchoosermulti = asm_widget({
                 dialog.find("table > tbody").html(h);
                 // Remove any existing events from previous searches
                 dialog.off("click", "a");
-                // Use delegation to bind click events for 
-                // the person once clicked. Triggers the change callback
-                dialog.on("click", "a", function(e) {
-                    let rec = people[$(this).attr("data")];
-                    t.val(rec.ID);
-                    t.data("selected", rec);
-                    display.html(self.render_display.call(self, t, rec));
-                    node.find(".personchooser-briefexpander").click(function() {
-                        let widget = $(this);
-                        if (widget.hasClass("ui-icon-triangle-1-e")) {
-                            widget.removeClass("ui-icon-triangle-1-e");
-                            widget.addClass("ui-icon-triangle-1-s");
-                            widget.closest(".personchooser-display").find(".personchooser-ownerinfo").slideDown(common.fx_speed);
-                        } else {
-                            widget.removeClass("ui-icon-triangle-1-s");
-                            widget.addClass("ui-icon-triangle-1-e");
-                            widget.closest(".personchooser-display").find(".personchooser-ownerinfo").slideUp(common.fx_speed);
-                        }
-                    });
-                    node.find(".personchooser-banned").val(rec.ISBANNED);
-                    node.find(".personchooser-idcheck").val(rec.IDCHECK);
-                    node.find(".personchooser-postcode").val(rec.OWNERPOSTCODE);
-                    try { validate.dirty(true); } catch(exp) { }
-                    // dialog.dialog("close");
-                    t.trigger("change", [ rec ]);
-                    return false;
-                });
                 dialog.find("table").trigger("update");
                 dialog.find("img").hide();
                 dialog.find("button").button("enable");
                 common.inject_target(); 
+                self.update_filters(t);
             },
             error: function(jqxhr, textstatus, response) {
                 // dialog.dialog("close");

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -94,7 +94,8 @@ $.fn.personchoosermulti = asm_widget({
                 }
             }
         });
-
+        o.dialog.find("table").table({ sticky_header: false });
+        o.dialog.find("input").keydown(function(event) { if (event.keyCode == 13) { self.find.call(self, t); return false; }});
         o.dialog.find("img").hide();
         o.dialog.find(".personchoosermulti-searchbutton").button().css("padding", ".2em 1em").css("top", "-1px");
 
@@ -140,12 +141,13 @@ $.fn.personchoosermulti = asm_widget({
     },
 
     /**
-     * Returns the person row with ID aid
+     * Returns the person row with ID pid
      */
-    get_row: function(t, aid) {
+    get_row: function(t, pid) {
         let rv, o = t.data("o");
+        console.log(o.rows);
         $.each(o.rows, function(i, v) {
-            if (v.ID == aid) {
+            if (v.ID == pid) {
                 rv = v;
             }
         });
@@ -186,8 +188,10 @@ $.fn.personchoosermulti = asm_widget({
         let self = this, o = t.data("o"), selval = [];
         o.display.html("");
         o.results.find(":checked").each(function() {
-            let aid = $(this).attr("data"), rec = self.get_row(t, aid);
-            selval.push(aid);
+            let pid = $(this).attr("data");
+            console.log(pid);
+            let rec = self.get_row(t, pid);
+            selval.push(pid);
             console.log(rec);
             let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.OWNERNAME + "</a>";
             o.display.append(disp);
@@ -209,9 +213,16 @@ $.fn.personchoosermulti = asm_widget({
             if (String(o.flags.val()).trim() && selflag.length > 0 && !common.array_overlap_all(selflag, a.ADDITIONALFLAGS.split("|"))) {
                 show = false;
             } else {
+                show = false;
                 let searchkey = o.dialog.find(".personchoosermulti-searchinput").val();
-                if (!a.OWNERNAME.toLowerCase().includes(searchkey.toLowerCase())) {
-                    show = false;
+                if (a.OWNERNAME.toLowerCase().includes(searchkey.toLowerCase())) {
+                    show = true;
+                } else if (a.OWNERADDRESS.toLowerCase().includes(searchkey.toLowerCase())) {
+                    show = true;
+                } else if (a.OWNERPOSTCODE.toLowerCase().replace(/ /g, "").includes(searchkey.toLowerCase().replace(/ /g, ""))) {
+                    show = true;
+                } else if (a.OWNERCODE.toLowerCase() == searchkey.toLowerCase()) {
+                    show = true;
                 }
             }
             // Show/hide the result appropriately
@@ -264,18 +275,21 @@ $.fn.personchoosermulti = asm_widget({
                 // Flags list
                 html.person_flag_options(null, rv.flags, o.flags);
                 //flags.html( html.list_to_options(rv.flags, "FLAG", "FLAG") );
-                o.flags.change();
+                // o.flags.change();
                 o.flags.on("change", function(e) {
+                    self.find.call(self, t);
                     self.update_filters(t);
                 });
                 o.search.on("click", function(e) {
+                    self.find.call(self, t);
                     self.update_filters(t);
                 });
 
                 // Load the list of people
-                $.each(o.rows, function(i, a) {
-                    o.results.append('<tr class="asm-personchoosermulti-result"><td><input type="checkbox" class="personselect" data="' + a.ID + '"> <a href="person?id="' + a.ID + '" target="_blank">' + a.OWNERNAME + '</a></td><td>' + a.OWNERCODE + '</td><td>' + a.OWNERADDRESS + '</td><td>' + a.OWNERPOSTCODE + ' </td></tr>');
-                });
+                // $.each(o.rows, function(i, a) {
+                //     console.log(a.ID);
+                //     o.results.append('<tr class="asm-personchoosermulti-result"><td><input type="checkbox" class="personselect" data="' + a.ID + '"> <a href="person?id=' + a.ID + '" target="_blank">' + a.OWNERNAME + '</a></td><td>' + a.OWNERCODE + '</td><td>' + a.OWNERADDRESS + '</td><td>' + a.OWNERPOSTCODE + ' </td></tr>');
+                // });
 
                 // Delegate event handler for the checkboxes
                 o.results.off("click", "input[type='checkbox']");
@@ -311,6 +325,77 @@ $.fn.personchoosermulti = asm_widget({
             error: function(jqxhr, textstatus, response) {
                 o.dialog.dialog("close");
                 o.dialog.find(".spinner").hide();
+                log.error(response);
+            }
+        });
+    },
+
+    find: function(t) {
+        let o = t.data("o");
+        let self = this, 
+            dialog = o.dialog,
+            node = o.node,
+            display = o.display;
+        dialog.find("img").show();
+        dialog.find("button").button("disable");
+        let q = encodeURIComponent(dialog.find("input").val());
+        let formdata = "mode=find&filter=all&type=all&q=" + q;
+        $.ajax({
+            type: "POST",
+            url:  "person_embed",
+            data: formdata,
+            dataType: "text",
+            success: function(data, textStatus, jqXHR) {
+                let h = "";
+                let people = jQuery.parseJSON(data);
+                o.rows = people;
+                $.each(people, function(i, p) {
+                    h += "<tr class=\"asm-personchoosermulti-result\">";
+                    h += "<td><input type=\"checkbox\" class=\"personselect\" data=\"" + p.ID + "\"><a href=\"#\" data=\"" + p.ID + "\">" + p.OWNERNAME + "</a></td>";
+                    h += "<td>" + p.OWNERCODE + "</td>";
+                    h += "<td>" + p.OWNERADDRESS + "</td>";
+                    h += "<td>" + p.OWNERPOSTCODE + "</td>";
+                    h += "</tr>";
+                });
+                dialog.find("table > tbody").html(h);
+                // Remove any existing events from previous searches
+                dialog.off("click", "a");
+                // Use delegation to bind click events for 
+                // the person once clicked. Triggers the change callback
+                dialog.on("click", "a", function(e) {
+                    let rec = people[$(this).attr("data")];
+                    t.val(rec.ID);
+                    t.data("selected", rec);
+                    display.html(self.render_display.call(self, t, rec));
+                    node.find(".personchooser-briefexpander").click(function() {
+                        let widget = $(this);
+                        if (widget.hasClass("ui-icon-triangle-1-e")) {
+                            widget.removeClass("ui-icon-triangle-1-e");
+                            widget.addClass("ui-icon-triangle-1-s");
+                            widget.closest(".personchooser-display").find(".personchooser-ownerinfo").slideDown(common.fx_speed);
+                        } else {
+                            widget.removeClass("ui-icon-triangle-1-s");
+                            widget.addClass("ui-icon-triangle-1-e");
+                            widget.closest(".personchooser-display").find(".personchooser-ownerinfo").slideUp(common.fx_speed);
+                        }
+                    });
+                    node.find(".personchooser-banned").val(rec.ISBANNED);
+                    node.find(".personchooser-idcheck").val(rec.IDCHECK);
+                    node.find(".personchooser-postcode").val(rec.OWNERPOSTCODE);
+                    try { validate.dirty(true); } catch(exp) { }
+                    // dialog.dialog("close");
+                    t.trigger("change", [ rec ]);
+                    return false;
+                });
+                dialog.find("table").trigger("update");
+                dialog.find("img").hide();
+                dialog.find("button").button("enable");
+                common.inject_target(); 
+            },
+            error: function(jqxhr, textstatus, response) {
+                // dialog.dialog("close");
+                dialog.find("img").hide();
+                dialog.find("button").button("enable");
                 log.error(response);
             }
         });

--- a/src/static/js/common_personchoosermulti.js
+++ b/src/static/js/common_personchoosermulti.js
@@ -124,6 +124,7 @@ $.fn.personchoosermulti = asm_widget({
         o.display.html("");
         o.results.find(":checked").prop("checked", false);
         this.update_status(t);
+        o.selectedrows = [];
         if (fireclearedevent) { t.trigger("cleared"); }
     },
 
@@ -187,11 +188,9 @@ $.fn.personchoosermulti = asm_widget({
     select: function(t) {
         let self = this, o = t.data("o"), selval = [];
         o.display.html("");
-        o.results.find(":checked").each(function() {
-            let pid = $(this).attr("data");
-            let rec = self.get_row(t, pid);
-            selval.push(pid);
-            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.OWNERNAME + "</a>";
+        $.each(o.selectedrows, function(i, p) {
+            selval.push(p.ID);
+            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + p.ID + "\">" + p.OWNERNAME + "</a>";
             o.display.append(disp);
             o.display.append("<br />");
         });
@@ -223,16 +222,6 @@ $.fn.personchoosermulti = asm_widget({
                     show = true;
                 }
             }
-            // Show/hide the result appropriately
-            // if (show && !o.selectedrows.includes(p)) {
-            //     o.selectedrows.push(p);
-            // } else if (!show && o.selectedrows.includes(p)) {
-            //     $.each([...o.selectedrows], function(i, r) {
-            //         if (r == p) {
-            //             o.selectedrows.splice(i, 1);
-            //         }
-            //     });
-            // }
             o.dialog.find(".personselect[data='" + p.ID + "']").closest(".asm-personchoosermulti-result").toggle(show);
         });
     },
@@ -243,7 +232,8 @@ $.fn.personchoosermulti = asm_widget({
     update_status: function(t) {
         let o = t.data("o");
         let c = o.selectedrows.length;
-        o.dialog.find(".totalselected").html(html.info(_("{0} selected").replace("{0}", c)));
+        let mc = _("{0} selected").replace("{0}", c);
+        o.dialog.find(".totalselected").html(html.info(mc));
         o.results.find(".asm-personchoosermulti-selected").removeClass("asm-personchoosermulti-selected").removeClass("ui-state-highlight");
         o.results.find(":checked").each(function() {
             let tn = $(this);
@@ -290,10 +280,7 @@ $.fn.personchoosermulti = asm_widget({
                     self.update_filters(t);
                 });
                 o.results.on("change", "input", function(e) {
-                    // console.log($(e.currentTarget));
-                    // console.log(o.rows);
                     let checkbox = $(e.currentTarget);
-                    console.log(checkbox.prop("checked"));
                     let rowid = checkbox.attr("data");
                     $.each(o.rows, function(i, r) {
                         if (r.ID == rowid) {
@@ -303,7 +290,6 @@ $.fn.personchoosermulti = asm_widget({
                                     rowpresent = true;
                                 }
                             });
-                            console.log("rowpresent = " + rowpresent);
                             if (checkbox.prop("checked") && !rowpresent) {
                                 o.selectedrows.push(r);
                             } else if (!checkbox.prop("checked") && rowpresent) {
@@ -316,7 +302,6 @@ $.fn.personchoosermulti = asm_widget({
                         }
                     });
                     self.update_status(t);
-                    console.log(o.selectedrows);
                 });
 
                 // Delegate event handler for the checkboxes
@@ -381,9 +366,7 @@ $.fn.personchoosermulti = asm_widget({
                     h += "<tr class=\"asm-personchoosermulti-result\">";
                     h += "<td><input type=\"checkbox\" class=\"personselect\" data=\"" + p.ID + "\"";
                     $.each(o.selectedrows, function(i, r) {
-                        if (r.ID == p.ID) {
-                            h += " checked";
-                        }
+                        if (r.ID == p.ID) { h += " checked"; }
                     });
                     h += "><a href=\"/person?id=" + p.ID + "\" data=\"" + p.ID + "\">" + p.OWNERNAME + "</a></td>";
                     h += "<td>" + p.OWNERCODE + "</td>";
@@ -433,24 +416,5 @@ $.fn.personchoosermulti = asm_widget({
                 log.error(response);
             }
         });
-    },
-
-    value: function(t, newval) {
-        // Possible race condition if this function is called before load function has completed
-        let self = this;
-        if (newval === undefined) { // Value is being extracted rather than updated
-            return t.val();
-        }
-        if (!newval) { newval = ""; }
-        t.val(newval);
-        let o = t.data("o");
-        o.display.html("");
-        $.each(newval.split(","), function(i, v) {
-            let rec = self.get_row(t, parseInt(v));
-            let disp = "<a class=\"asm-embed-name\" href=\"person?id=" + rec.ID + "\">" + rec.OWNERNAME + "</a>";
-            o.display.append(disp);
-            o.display.append("<br />");
-        });
-        self.selectbyids(t, newval, true);
     }
 });

--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1151,7 +1151,7 @@ const tableform = {
      *        options: "<option>test</option>"
      *        options: { displayfield: "DISPLAY", valuefield: "VALUE", rows: [ {rows} ], prepend: "<option>extra</option>" }, 
      *        animalfilter: "all",   (only valid for animal and animalmulti types)
-     *        personfilter: "all",   (only valid for person type)
+     *        personfilter: "all",   (only valid for person and personmulti type)
      *        persontype: "all",   (only valid for person type, other options individual or organization)
      *        personmode: "full",    (only valid for person type)
      *        change: function(changeevent), (note: done in fields_bind, not here)
@@ -1193,6 +1193,7 @@ const tableform = {
         $.each(fields, function(i, v) {
             if (v.type == "animal") { d += tableform.render_animal(v); }
             else if (v.type == "animalmulti") { d += tableform.render_animalmulti(v); }
+            else if (v.type == "personmulti") { d += tableform.render_personmulti(v); }
             else if (v.type == "autotext") { d += tableform.render_autotext(v); }
             else if (v.type == "check") { d += tableform.render_check(v); }
             else if (v.type == "currency") { d += tableform.render_currency(v); }
@@ -1428,6 +1429,25 @@ const tableform = {
         if (v.extraattributes)
         if (v.readonly) { d += "data-noedit=\"true\" "; }
         if (v.animalfilter) { d += "data-filter=\"" + v.animalfilter + "\" "; }
+        if (v.validation) { d += tableform._render_validation_attr(v); }
+        if (v.value) { d += "value=\"" + tableform._attr_value(v.value) + "\" "; }
+        if (v.xattr) { d += v.xattr + " "; }
+        d += "/>";
+        return tableform._render_formfield(v, d);
+    },
+
+    render_personmulti: function(v) {
+        let d = "";
+        tableform._check_id(v);
+        d += "<input type=\"hidden\" ";
+        d += tableform._render_class(v, "asm-personchoosermulti");
+        if (v.id) { d += "id=\"" + v.id + "\" "; }
+        if (v.name) { d += "name=\"" + v.name + "\" "; }
+        if (v.json_field) { d += "data-json=\"" + v.json_field + "\" "; }
+        if (v.post_field) { d += "data-post=\"" + v.post_field + "\" "; }
+        if (v.extraattributes)
+        if (v.readonly) { d += "data-noedit=\"true\" "; }
+        if (v.personfilter) { d += "data-filter=\"" + v.personfilter + "\" "; }
         if (v.validation) { d += tableform._render_validation_attr(v); }
         if (v.value) { d += "value=\"" + tableform._attr_value(v.value) + "\" "; }
         if (v.xattr) { d += v.xattr + " "; }
@@ -2033,6 +2053,7 @@ const tableform = {
                 else if (v.type == "currency") { $("#" + v.post_field).currency("value", 0); return; }
                 else if (v.type == "animal") { $("#" + v.post_field).animalchooser("clear"); return; }
                 else if (v.type == "animalmulti") { $("#" + v.post_field).animalchoosermulti("clear"); return; }
+                else if (v.type == "personmulti") { $("#" + v.post_field).personchoosermulti("clear"); return; }
                 else if (v.type == "datetime") { $("#" + v.post_field + "date, #" + v.post_field + "time").val(""); return; }
                 else if (v.type == "person") { $("#" + v.post_field).personchooser("clear"); return; }
                 else if (v.type == "textarea") { $("#" + v.post_field).val("");  return; }
@@ -2087,6 +2108,10 @@ const tableform = {
             else if (v.type == "animalmulti") {
                 n.animalchoosermulti("clear");
                 n.animalchoosermulti("selectbyids", row[v.json_field]);
+            }
+            else if (v.type == "personmulti") {
+                n.personchoosermulti("clear");
+                n.personchoosermulti("selectbyids", row[v.json_field]);
             }
             else if (v.type == "person") {
                 n.personchooser("clear", false);

--- a/src/static/js/move_adopt.js
+++ b/src/static/js/move_adopt.js
@@ -20,7 +20,7 @@ $(function() {
                 html.info('<span id="warntext"></span>', "ownerwarn"),
                 tableform.fields_render([
                     { post_field: "animal", label: _("Animal"), type: "animal" },
-                    { post_field: "person", label: _("New Owner"), type: "personmulti" },
+                    { post_field: "person", label: _("New Owner"), type: "person" },
                     { post_field: "source", label: _("Adoption Source"), type: "select",
                         options: { displayfield: "SOURCENAME", valuefield: "ID", rows: controller.adoptionsources, prepend: '<option value="0"></option>' }
                     },

--- a/src/static/js/move_adopt.js
+++ b/src/static/js/move_adopt.js
@@ -20,7 +20,7 @@ $(function() {
                 html.info('<span id="warntext"></span>', "ownerwarn"),
                 tableform.fields_render([
                     { post_field: "animal", label: _("Animal"), type: "animal" },
-                    { post_field: "person", label: _("New Owner"), type: "person" },
+                    { post_field: "person", label: _("New Owner"), type: "personmulti" },
                     { post_field: "source", label: _("Adoption Source"), type: "select",
                         options: { displayfield: "SOURCENAME", valuefield: "ID", rows: controller.adoptionsources, prepend: '<option value="0"></option>' }
                     },

--- a/src/static/js/move_reserve.js
+++ b/src/static/js/move_reserve.js
@@ -86,7 +86,6 @@ $(function() {
             $("#person").on("change", async function(event, rec) {
                 let response = await edit_header.person_with_adoption_warnings(rec.ID);
                 let p = jQuery.parseJSON(response)[0];
-                console.log("AJAX executed");
                 $("#ownerwarn").hide();
          
                 // Default giftaid if the person is registered

--- a/src/static/js/move_reserve.js
+++ b/src/static/js/move_reserve.js
@@ -17,7 +17,7 @@ $(function() {
                 html.textbar(_("This animal is not on the shelter."), { id: "notonshelter", state: "error", icon: "alert", maxwidth: "600px" }),
                 tableform.fields_render([
                     { post_field: "animal", label: _("Animal"), type: "animal" },
-                    { post_field: "person", label: _("Reservation For"), type: "personmulti" },
+                    { post_field: "person", label: _("Reservation For"), type: "person" },
                     { post_field: "source", label: _("Adoption Source"), type: "select",
                         options: { displayfield: "SOURCENAME", valuefield: "ID", rows: controller.adoptionsources, prepend: '<option value="0"></option>' }
                     },
@@ -86,7 +86,7 @@ $(function() {
             $("#person").on("change", async function(event, rec) {
                 let response = await edit_header.person_with_adoption_warnings(rec.ID);
                 let p = jQuery.parseJSON(response)[0];
-
+                
                 $("#ownerwarn").hide();
          
                 // Default giftaid if the person is registered

--- a/src/static/js/move_reserve.js
+++ b/src/static/js/move_reserve.js
@@ -16,8 +16,8 @@ $(function() {
                 html.textbar(_("This animal already has an active reservation."), { id: "multiplereserve", state: "error", icon: "alert", maxwidth: "600px" }),
                 html.textbar(_("This animal is not on the shelter."), { id: "notonshelter", state: "error", icon: "alert", maxwidth: "600px" }),
                 tableform.fields_render([
-                    { post_field: "animal", label: _("Animal"), type: "animal" },
-                    { post_field: "person", label: _("Reservation For"), type: "person" },
+                    { post_field: "animal", label: _("Animal"), type: "animalmulti" }, // Changed for testing, need the multi removing before production
+                    { post_field: "person", label: _("Reservation For"), type: "personmulti" },  // Changed for testing, need the multi removing before production
                     { post_field: "source", label: _("Adoption Source"), type: "select",
                         options: { displayfield: "SOURCENAME", valuefield: "ID", rows: controller.adoptionsources, prepend: '<option value="0"></option>' }
                     },
@@ -84,24 +84,25 @@ $(function() {
 
             // Callback when person is changed
             $("#person").on("change", async function(event, rec) {
-                let response = await edit_header.person_with_adoption_warnings(rec.ID);
-                let p = jQuery.parseJSON(response)[0];
-
-                $("#ownerwarn").hide();
+                // console.log("Changed");
+                // let response = await edit_header.person_with_adoption_warnings(rec.ID);
+                // let p = jQuery.parseJSON(response)[0];
+                // console.log("AJAX executed");
+                // $("#ownerwarn").hide();
          
-                // Default giftaid if the person is registered
-                if (common.has_permission("oaod")) {
-                    $("#payment").payments("set_giftaid", p.ISGIFTAID == 1);
-                    $("#giftaid1").prop("checked", p.ISGIFTAID == 1);
-                }
+                // // Default giftaid if the person is registered
+                // if (common.has_permission("oaod")) {
+                //     $("#payment").payments("set_giftaid", p.ISGIFTAID == 1);
+                //     $("#giftaid1").prop("checked", p.ISGIFTAID == 1);
+                // }
 
-                let oopostcode = $(".animalchooser-oopostcode").val();
-                let bipostcode = $(".animalchooser-bipostcode").val(); 
-                let warn = html.person_movement_warnings(p, oopostcode, bipostcode);
-                if (warn.length > 0) {
-                    $("#warntext").html(warn.join("<br>"));
-                    $("#ownerwarn").show();
-                }
+                // let oopostcode = $(".animalchooser-oopostcode").val();
+                // let bipostcode = $(".animalchooser-bipostcode").val(); 
+                // let warn = html.person_movement_warnings(p, oopostcode, bipostcode);
+                // if (warn.length > 0) {
+                //     $("#warntext").html(warn.join("<br>"));
+                //     $("#ownerwarn").show();
+                // }
             });
 
             // Payments

--- a/src/static/js/move_reserve.js
+++ b/src/static/js/move_reserve.js
@@ -16,8 +16,8 @@ $(function() {
                 html.textbar(_("This animal already has an active reservation."), { id: "multiplereserve", state: "error", icon: "alert", maxwidth: "600px" }),
                 html.textbar(_("This animal is not on the shelter."), { id: "notonshelter", state: "error", icon: "alert", maxwidth: "600px" }),
                 tableform.fields_render([
-                    { post_field: "animal", label: _("Animal"), type: "animalmulti" }, // Changed for testing, need the multi removing before production
-                    { post_field: "person", label: _("Reservation For"), type: "personmulti" },  // Changed for testing, need the multi removing before production
+                    { post_field: "animal", label: _("Animal"), type: "animal" },
+                    { post_field: "person", label: _("Reservation For"), type: "person" },
                     { post_field: "source", label: _("Adoption Source"), type: "select",
                         options: { displayfield: "SOURCENAME", valuefield: "ID", rows: controller.adoptionsources, prepend: '<option value="0"></option>' }
                     },
@@ -84,25 +84,24 @@ $(function() {
 
             // Callback when person is changed
             $("#person").on("change", async function(event, rec) {
-                // console.log("Changed");
-                // let response = await edit_header.person_with_adoption_warnings(rec.ID);
-                // let p = jQuery.parseJSON(response)[0];
-                // console.log("AJAX executed");
-                // $("#ownerwarn").hide();
+                let response = await edit_header.person_with_adoption_warnings(rec.ID);
+                let p = jQuery.parseJSON(response)[0];
+                console.log("AJAX executed");
+                $("#ownerwarn").hide();
          
-                // // Default giftaid if the person is registered
-                // if (common.has_permission("oaod")) {
-                //     $("#payment").payments("set_giftaid", p.ISGIFTAID == 1);
-                //     $("#giftaid1").prop("checked", p.ISGIFTAID == 1);
-                // }
+                // Default giftaid if the person is registered
+                if (common.has_permission("oaod")) {
+                    $("#payment").payments("set_giftaid", p.ISGIFTAID == 1);
+                    $("#giftaid1").prop("checked", p.ISGIFTAID == 1);
+                }
 
-                // let oopostcode = $(".animalchooser-oopostcode").val();
-                // let bipostcode = $(".animalchooser-bipostcode").val(); 
-                // let warn = html.person_movement_warnings(p, oopostcode, bipostcode);
-                // if (warn.length > 0) {
-                //     $("#warntext").html(warn.join("<br>"));
-                //     $("#ownerwarn").show();
-                // }
+                let oopostcode = $(".animalchooser-oopostcode").val();
+                let bipostcode = $(".animalchooser-bipostcode").val(); 
+                let warn = html.person_movement_warnings(p, oopostcode, bipostcode);
+                if (warn.length > 0) {
+                    $("#warntext").html(warn.join("<br>"));
+                    $("#ownerwarn").show();
+                }
             });
 
             // Payments

--- a/src/static/js/move_reserve.js
+++ b/src/static/js/move_reserve.js
@@ -86,6 +86,7 @@ $(function() {
             $("#person").on("change", async function(event, rec) {
                 let response = await edit_header.person_with_adoption_warnings(rec.ID);
                 let p = jQuery.parseJSON(response)[0];
+                
                 $("#ownerwarn").hide();
          
                 // Default giftaid if the person is registered

--- a/src/static/js/move_reserve.js
+++ b/src/static/js/move_reserve.js
@@ -17,7 +17,7 @@ $(function() {
                 html.textbar(_("This animal is not on the shelter."), { id: "notonshelter", state: "error", icon: "alert", maxwidth: "600px" }),
                 tableform.fields_render([
                     { post_field: "animal", label: _("Animal"), type: "animal" },
-                    { post_field: "person", label: _("Reservation For"), type: "person" },
+                    { post_field: "person", label: _("Reservation For"), type: "personmulti" },
                     { post_field: "source", label: _("Adoption Source"), type: "select",
                         options: { displayfield: "SOURCENAME", valuefield: "ID", rows: controller.adoptionsources, prepend: '<option value="0"></option>' }
                     },
@@ -86,7 +86,7 @@ $(function() {
             $("#person").on("change", async function(event, rec) {
                 let response = await edit_header.person_with_adoption_warnings(rec.ID);
                 let p = jQuery.parseJSON(response)[0];
-                
+
                 $("#ownerwarn").hide();
          
                 // Default giftaid if the person is registered


### PR DESCRIPTION
We have a widget for choosing multiple animals, it would be really useful if we had a similar widget for choosing multiple people.

This widget could then be used to implement a bulk change screen for people (on a future ticket).

The widget itself would be very similar to animalchoosermulti in the page (ie. that you get a long list of the selected elements and no ability to add), but with a popup dialog very similar to personchooser. In addition to the search text at the top, it should also have a multiselect dropdown that allows you to filter people by flag. Selecting multiple flags requires that you get people who have all of the flags selected.

The person results would have checkboxes at the side to enable the selection.