### PR TITLE
Recent incidents minimap

### DIFF
--- a/src/asm3/animalcontrol.py
+++ b/src/asm3/animalcontrol.py
@@ -244,6 +244,36 @@ def get_animalcontrol_find_advanced(dbo: Database, criteria: dict, username: str
     sql = "%s WHERE %s ORDER BY ac.ID DESC" % (get_animalcontrol_query(dbo), " AND ".join(ss.ands))
     return reduce_find_results(dbo, username, dbo.query(sql, ss.values, limit=limit, distincton="ID"))
 
+def get_recent_incidents(dbo: Database):
+    now = dbo.now()
+    sql = "SELECT ac.ID, t.IncidentName, ac.DispatchLatLong AS LatLong, ac.DispatchAddress AS Address, o.OwnerName, 0 AS IncidentType FROM " \
+    "animalcontrol ac " \
+    "LEFT JOIN owner o ON ac.OwnerID = o.ID " \
+    "LEFT JOIN incidenttype t ON ac.IncidentTypeID = t.ID " \
+    "WHERE ac.IncidentDateTime BETWEEN ? AND ? " \
+    f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 1 AS IncidentType " \
+    "FROM animal a " \
+    "INNER JOIN adoption m ON a.ID = m.AnimalID AND m.MovementType = ? " \
+    "INNER JOIN owner o ON m.OwnerID = o.ID " \
+    "WHERE m.MovementDate BETWEEN ? AND ? " \
+    f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 2 AS IncidentType " \
+    "FROM animal a " \
+    "INNER JOIN owner o ON a.OwnerID = o.ID " \
+    "WHERE a.NonShelterAnimal = 1 AND a.DateBroughtIn BETWEEN ? AND ? " \
+    "AND o.OwnerTown = ? "
+    return dbo.query(sql,
+        (
+            dbo.sql_date(dbo.today(offset=-90)),
+            now,
+            asm3.movement.RECLAIMED,
+            dbo.sql_date(dbo.today(offset=-90)),
+            now,
+            dbo.sql_date(dbo.today(offset=-365)),
+            now,
+            asm3.configuration.organisation_town(dbo)
+        )
+    )
+
 def reduce_find_results(dbo: Database, username: str, rows: Results) -> Results:
     """
     Given the results of a find operation, goes through the results and removes 

--- a/src/asm3/animalcontrol.py
+++ b/src/asm3/animalcontrol.py
@@ -263,8 +263,8 @@ def get_recent_incidents(dbo: Database):
     f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 'asm-nonshelterpin' AS PinStyle " \
     "FROM animal a " \
     "INNER JOIN owner o ON a.OwnerID = o.ID " \
-    "WHERE a.NonShelterAnimal = 1 AND a.DateBroughtIn BETWEEN ? AND ? " \
-    "AND o.OwnerTown = ? "
+    "WHERE a.NonShelterAnimal = 1 AND a.DateBroughtIn BETWEEN ? AND ? "
+    # "AND o.OwnerTown = ? "
     return dbo.query(sql,
         (
             dbo.sql_date(dbo.today(offset=-90)),
@@ -273,8 +273,8 @@ def get_recent_incidents(dbo: Database):
             dbo.sql_date(dbo.today(offset=-90)),
             now,
             dbo.sql_date(dbo.today(offset=-365)),
-            now,
-            asm3.configuration.organisation_town(dbo)
+            now
+            # asm3.configuration.organisation_town(dbo)
         )
     )
 

--- a/src/asm3/animalcontrol.py
+++ b/src/asm3/animalcontrol.py
@@ -245,18 +245,22 @@ def get_animalcontrol_find_advanced(dbo: Database, criteria: dict, username: str
     return reduce_find_results(dbo, username, dbo.query(sql, ss.values, limit=limit, distincton="ID"))
 
 def get_recent_incidents(dbo: Database):
+    """
+    Returns rows of animalcontrol incidents and animals reclaimed in the last 3 months plus any 
+    non-shelter animals created in last year
+    """
     now = dbo.now()
-    sql = "SELECT ac.ID, t.IncidentName, ac.DispatchLatLong AS LatLong, ac.DispatchAddress AS Address, o.OwnerName, 0 AS IncidentType FROM " \
-    "animalcontrol ac " \
+    sql = "SELECT ac.ID, t.IncidentName, ac.DispatchLatLong AS LatLong, ac.DispatchAddress AS Address, o.OwnerName, 'asm-incidentpin' AS PinStyle " \
+    "FROM animalcontrol ac " \
     "LEFT JOIN owner o ON ac.OwnerID = o.ID " \
     "LEFT JOIN incidenttype t ON ac.IncidentTypeID = t.ID " \
     "WHERE ac.IncidentDateTime BETWEEN ? AND ? " \
-    f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 1 AS IncidentType " \
+    f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 'asm-reclaimedpin' AS PinStyle " \
     "FROM animal a " \
     "INNER JOIN adoption m ON a.ID = m.AnimalID AND m.MovementType = ? " \
     "INNER JOIN owner o ON m.OwnerID = o.ID " \
     "WHERE m.MovementDate BETWEEN ? AND ? " \
-    f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 2 AS IncidentType " \
+    f"UNION SELECT a.ID, {dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName"))} AS IncidentName, o.LatLong, o.OwnerAddress AS Address, o.OwnerName, 'asm-nonshelterpin' AS PinStyle " \
     "FROM animal a " \
     "INNER JOIN owner o ON a.OwnerID = o.ID " \
     "WHERE a.NonShelterAnimal = 1 AND a.DateBroughtIn BETWEEN ? AND ? " \

--- a/src/asm3/html.py
+++ b/src/asm3/html.py
@@ -554,6 +554,7 @@ def menu_structure(l: str, publisherlist: Dict, reports: MenuItems, mailmerges: 
             ( asm3.users.ADD_INCIDENT, "alt+shift+i", "taganimalcontrol", "incident_new", "asm-icon-blank", _("Report a new incident", l) ),
             ( asm3.users.VIEW_INCIDENT, "", "taganimalcontrol", "incident_find", "asm-icon-blank", _("Find incident", l) ),
             ( asm3.users.VIEW_INCIDENT, "", "taganimalcontrol", "incident_map", "asm-icon-map", _("Map of active incidents", l) ),
+            ( asm3.users.VIEW_INCIDENT, "", "taganimalcontrol", "recent_incident_map", "asm-icon-hold", _("Map of recent incidents", l) ),
             ( asm3.users.VIEW_TRAPLOAN, "", "tagtraploan", "traploan?filter=active", "asm-icon-traploan", _("Equipment loans", l) ),
             ( asm3.users.VIEW_LICENCE, "", "taganimalcontrol", "licence?offset=i31", "asm-icon-licence", _("Licensing", l) ),
             ( asm3.users.ADD_LICENCE, "", "taganimalcontrol", "licence_renewal", "asm-icon-blank", _("Renew license", l) ),

--- a/src/main.py
+++ b/src/main.py
@@ -4576,6 +4576,21 @@ class incident_map(JSONEndpoint):
             "rows": rows
         }
 
+class recent_incident_map(JSONEndpoint):
+    url = "recent_incident_map"
+    js_module = "incident_map"
+    get_permissions = asm3.users.VIEW_INCIDENT
+
+    def controller(self, o):
+        dbo = o.dbo
+        incidentrows = asm3.animalcontrol.get_recent_incidents(dbo)
+
+        rows = incidentrows
+        asm3.al.debug("incident map, %d active" % (len(rows)), "main.incident_map", dbo)
+        return {
+            "rows": rows
+        }
+
 class incident_media(JSONEndpoint):
     url = "incident_media"
     js_module = "media"

--- a/src/main.py
+++ b/src/main.py
@@ -4580,14 +4580,12 @@ class incident_map(JSONEndpoint):
 class recent_incident_map(JSONEndpoint):
     url = "recent_incident_map"
     js_module = "incident_map"
-    get_permissions = asm3.users.VIEW_INCIDENT
+    get_permissions = ( asm3.users.VIEW_INCIDENT, asm3.users.VIEW_MOVEMENT )
 
     def controller(self, o):
         dbo = o.dbo
-        incidentrows = asm3.animalcontrol.get_recent_incidents(dbo)
-
-        rows = incidentrows
-        asm3.al.debug("incident map, %d active" % (len(rows)), "main.incident_map", dbo)
+        rows = asm3.animalcontrol.get_recent_incidents(dbo)
+        asm3.al.debug("recent_incident map, %d active" % (len(rows)), "main.recent_incident_map", dbo)
         return {
             "rows": rows,
             "name": "recent_incident_map"

--- a/src/main.py
+++ b/src/main.py
@@ -4573,7 +4573,8 @@ class incident_map(JSONEndpoint):
         rows = asm3.animalcontrol.get_animalcontrol_find_advanced(dbo, { "filter": "incomplete" }, o.user)
         asm3.al.debug("incident map, %d active" % (len(rows)), "main.incident_map", dbo)
         return {
-            "rows": rows
+            "rows": rows,
+            "name": "active_incident_map"
         }
 
 class recent_incident_map(JSONEndpoint):
@@ -4588,7 +4589,8 @@ class recent_incident_map(JSONEndpoint):
         rows = incidentrows
         asm3.al.debug("incident map, %d active" % (len(rows)), "main.incident_map", dbo)
         return {
-            "rows": rows
+            "rows": rows,
+            "name": "recent_incident_map"
         }
 
 class incident_media(JSONEndpoint):

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1131,6 +1131,17 @@ select:disabled, input:disabled, textarea:disabled {
     width: 113px;
 }
 
+/** Leaflet pins */
+/* .asm-incidentpin {
+    filter: hue-rotate(120deg);
+} */
+.asm-nonshelterpin {
+    filter: hue-rotate(120deg);
+}
+.asm-reclaimedpin {
+    filter: hue-rotate(90deg);
+}
+
 /** Don't display the menu burger button when >480px */
 #asm-menu-burger {
     display: none;

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1132,14 +1132,14 @@ select:disabled, input:disabled, textarea:disabled {
 }
 
 /** Leaflet pins */
-/* .asm-incidentpin {
-    filter: hue-rotate(120deg);
-} */
+.asm-incidentpin {
+    filter: hue-rotate(0deg); /* Blue */
+}
 .asm-nonshelterpin {
-    filter: hue-rotate(120deg);
+    filter: hue-rotate(180deg); /* Orange */
 }
 .asm-reclaimedpin {
-    filter: hue-rotate(90deg);
+    filter: hue-rotate(90deg); /* Purple */
 }
 
 /** Don't display the menu burger button when >480px */

--- a/src/static/js/common_map.js
+++ b/src/static/js/common_map.js
@@ -19,12 +19,14 @@ const mapping = {
     draw_map: function(divid, zoom, latlong, markers) {
         var _draw_map = function(latlong) {
             if (asm.mapprovider == "osm") {
+                console.log("Drawing");
                 mapping._leaflet_draw_map(divid, zoom, latlong, markers);
             }
             else if (asm.mapprovider == "google") {
                 mapping._google_draw_map(divid, zoom, latlong, markers);
             }
         };
+        console.log("Drawing");
         var first_valid = this._first_valid_latlong(markers);
         // A center point has been specified, use that
         if (latlong != "") {
@@ -75,6 +77,7 @@ const mapping = {
     },
 
     _leaflet_draw_map: function(divid, zoom, latlong, markers) {
+        console.log("Drawing");
         $("head").append('<link rel="stylesheet" href="' + asm.leafletcss + '" />');
         mapping._get_script(asm.leafletjs, function() {
             var ll = latlong.split(",");
@@ -87,12 +90,21 @@ const mapping = {
                     '<a target="_blank" href="https://www.openstreetmap.org/fixthemap">Improve this map</a>'
             }).addTo(map);
             L.control.scale().addTo(map);
+            console.log("Drawing");
             $.each(markers, function(i, v) {
                 if (!v.latlong || v.latlong.indexOf("0,0") == 0) { return; }
                 ll = v.latlong.split(",");
                 var marker = L.marker([ll[0], ll[1]]).addTo(map);
+                // if (v.INCIDENTTYPE == 1) {
+                //     marker._icon.classList.add("asm-reclaimedpin");
+                // } else if (v.INCIDENTTYPE == 2) {
+                //     marker._icon.classList.add("asm-nonshelterpin");
+                // } else {
+                //      marker._icon.classList.add("asm-incidentpin");
+                // }
                 if (v.popuptext) { marker.bindPopup(v.popuptext); }
                 if (v.popupactive) { marker.openPopup(); }
+                console.log(marker);
             });
             if (config.bool("ShowLatLong")) {
                 map.on("contextmenu", function (event) {

--- a/src/static/js/common_map.js
+++ b/src/static/js/common_map.js
@@ -19,14 +19,12 @@ const mapping = {
     draw_map: function(divid, zoom, latlong, markers) {
         var _draw_map = function(latlong) {
             if (asm.mapprovider == "osm") {
-                console.log("Drawing");
                 mapping._leaflet_draw_map(divid, zoom, latlong, markers);
             }
             else if (asm.mapprovider == "google") {
                 mapping._google_draw_map(divid, zoom, latlong, markers);
             }
         };
-        console.log("Drawing");
         var first_valid = this._first_valid_latlong(markers);
         // A center point has been specified, use that
         if (latlong != "") {
@@ -77,7 +75,6 @@ const mapping = {
     },
 
     _leaflet_draw_map: function(divid, zoom, latlong, markers) {
-        console.log("Drawing");
         $("head").append('<link rel="stylesheet" href="' + asm.leafletcss + '" />');
         mapping._get_script(asm.leafletjs, function() {
             var ll = latlong.split(",");
@@ -90,21 +87,19 @@ const mapping = {
                     '<a target="_blank" href="https://www.openstreetmap.org/fixthemap">Improve this map</a>'
             }).addTo(map);
             L.control.scale().addTo(map);
-            console.log("Drawing");
             $.each(markers, function(i, v) {
                 if (!v.latlong || v.latlong.indexOf("0,0") == 0) { return; }
                 ll = v.latlong.split(",");
                 var marker = L.marker([ll[0], ll[1]]).addTo(map);
-                // if (v.INCIDENTTYPE == 1) {
-                //     marker._icon.classList.add("asm-reclaimedpin");
-                // } else if (v.INCIDENTTYPE == 2) {
-                //     marker._icon.classList.add("asm-nonshelterpin");
-                // } else {
-                //      marker._icon.classList.add("asm-incidentpin");
-                // }
+                if (v.INCIDENTTYPE == 1) {
+                    marker._icon.classList.add("asm-reclaimedpin");
+                } else if (v.INCIDENTTYPE == 2) {
+                    marker._icon.classList.add("asm-nonshelterpin");
+                } else {
+                     marker._icon.classList.add("asm-incidentpin");
+                }
                 if (v.popuptext) { marker.bindPopup(v.popuptext); }
                 if (v.popupactive) { marker.openPopup(); }
-                console.log(marker);
             });
             if (config.bool("ShowLatLong")) {
                 map.on("contextmenu", function (event) {

--- a/src/static/js/common_map.js
+++ b/src/static/js/common_map.js
@@ -91,6 +91,7 @@ const mapping = {
                 if (!v.latlong || v.latlong.indexOf("0,0") == 0) { return; }
                 ll = v.latlong.split(",");
                 var marker = L.marker([ll[0], ll[1]]).addTo(map);
+                if (v.popuptext) { marker.bindPopup(v.popuptext); }
                 if (v.PINSTYLE) { marker._icon.classList.add(v.PINSTYLE); }
                 if (v.popupactive) { marker.openPopup(); }
             });

--- a/src/static/js/common_map.js
+++ b/src/static/js/common_map.js
@@ -91,14 +91,7 @@ const mapping = {
                 if (!v.latlong || v.latlong.indexOf("0,0") == 0) { return; }
                 ll = v.latlong.split(",");
                 var marker = L.marker([ll[0], ll[1]]).addTo(map);
-                if (v.INCIDENTTYPE == 1) {
-                    marker._icon.classList.add("asm-reclaimedpin");
-                } else if (v.INCIDENTTYPE == 2) {
-                    marker._icon.classList.add("asm-nonshelterpin");
-                } else {
-                     marker._icon.classList.add("asm-incidentpin");
-                }
-                if (v.popuptext) { marker.bindPopup(v.popuptext); }
+                if (v.PINSTYLE) { marker._icon.classList.add(v.PINSTYLE); }
                 if (v.popupactive) { marker.openPopup(); }
             });
             if (config.bool("ShowLatLong")) {

--- a/src/static/js/incident_map.js
+++ b/src/static/js/incident_map.js
@@ -33,10 +33,13 @@ $(function() {
                 } else {
                     v.latlong = v.LATLONG;
                 }
-                if (v.INCIDENTTYPE == 1) {
+                if (v.DISPATCHADDRESS) {
+                    v.ADDRESS = v.DISPATCHADDRESS;
+                }
+                if (v.PINSTYLE == "asm-reclaimedpin") {
                     v.popuptext = "<b>" + v.ADDRESS + "</b><br /><a target='_blank' href='animal?id=" + v.ID + "'>" + 
                         v.INCIDENTNAME + " " + _("Reclaimed") + "</a>";
-                } else if (v.INCIDENTTYPE == 2) {
+                } else if (v.PINSTYLE == "asm-nonshelterpin") {
                     v.popuptext = "<b>" + v.ADDRESS + "</b><br /><a target='_blank' href='animal?id=" + v.ID + "'>" + 
                         v.INCIDENTNAME + " " + _("Non-Shelter") + "</a>";
                 } else {

--- a/src/static/js/incident_map.js
+++ b/src/static/js/incident_map.js
@@ -23,9 +23,17 @@ $(function() {
         delay: function() {
             let first_valid = "";
             $.each(controller.rows, function(i, v) {
-                v.latlong = v.DISPATCHLATLONG;
-                v.popuptext = "<b>" + v.DISPATCHADDRESS + "</b><br /><a target='_blank' href='incident?id=" + v.ACID + "'>" + 
-                    v.INCIDENTNAME + " " + common.nulltostr(v.OWNERNAME) + "</a>";
+                v.latlong = v.LATLONG;
+                if (v.INCIDENTTYPE == 1) {
+                    v.popuptext = "<b>" + v.ADDRESS + "</b><br /><a target='_blank' href='animal?id=" + v.ID + "'>" + 
+                        v.INCIDENTNAME + " " + _("Reclaimed") + "</a>";
+                } else if (v.INCIDENTTYPE == 2) {
+                    v.popuptext = "<b>" + v.ADDRESS + "</b><br /><a target='_blank' href='animal?id=" + v.ID + "'>" + 
+                        v.INCIDENTNAME + " " + _("Non-Shelter") + "</a>";
+                } else {
+                    v.popuptext = "<b>" + v.ADDRESS + "</b><br /><a target='_blank' href='incident?id=" + v.ID + "'>" + 
+                        v.INCIDENTNAME + " " + common.nulltostr(v.OWNERNAME) + "</a>";
+                }
                 if (v.latlong && v.latlong.indexOf("0,0") == -1) { first_valid = v.latlong; }
             });
             mapping.draw_map("embeddedmap", 10, first_valid, controller.rows); 
@@ -33,8 +41,15 @@ $(function() {
 
         name: "incident_map",
         animation: "results",
-        title: function() { return _("Active Incidents"); },
+        title: function() {
+            if (controller.name == "incident_map") {
+                return _("Active Incidents");
+            } else {
+                return _("Recent Incidents");
+            }
+        },
         routes: {
+            "recent_incident_map": function() { common.module_loadandstart("incident_map", "incident_map"); },
             "incident_map": function() { common.module_loadandstart("incident_map", "incident_map"); }
         }
 

--- a/src/static/js/incident_map.js
+++ b/src/static/js/incident_map.js
@@ -49,7 +49,7 @@ $(function() {
             }
         },
         routes: {
-            "recent_incident_map": function() { common.module_loadandstart("incident_map", "incident_map"); },
+            "recent_incident_map": function() { common.module_loadandstart("incident_map", "recent_incident_map"); },
             "incident_map": function() { common.module_loadandstart("incident_map", "incident_map"); }
         }
 

--- a/src/static/js/incident_map.js
+++ b/src/static/js/incident_map.js
@@ -12,7 +12,6 @@ $(function() {
             if (controller.name == "recent_incident_map") {
                 title = _("Recent Incidents");
             }
-            console.log(title);
             return [
                 html.content_header(title),
                 '<div id="embeddedmap" style="position: absolute;z-index: 1; width: 100%; height: calc(100% - ' + headerheight + 'px); color: #000"></div>',

--- a/src/static/js/incident_map.js
+++ b/src/static/js/incident_map.js
@@ -7,9 +7,10 @@ $(function() {
     const incident_map = {
 
         render: function() {
+            let headerheight = $("body").outerHeight() + 50;
             return [
                 html.content_header(_("Active Incidents")),
-                '<div id="embeddedmap" style="z-index: 1; width: 100%; height: 600px; color: #000"></div>',
+                '<div id="embeddedmap" style="position: absolute;z-index: 1; width: 100%; height: calc(100% - ' + headerheight + 'px); color: #000"></div>',
                 html.content_footer()
             ].join("\n");
         },
@@ -23,7 +24,11 @@ $(function() {
         delay: function() {
             let first_valid = "";
             $.each(controller.rows, function(i, v) {
-                v.latlong = v.LATLONG;
+                if (v.DISPATCHLATLONG) {
+                    v.latlong = v.DISPATCHLATLONG;
+                } else {
+                    v.latlong = v.LATLONG;
+                }
                 if (v.INCIDENTTYPE == 1) {
                     v.popuptext = "<b>" + v.ADDRESS + "</b><br /><a target='_blank' href='animal?id=" + v.ID + "'>" + 
                         v.INCIDENTNAME + " " + _("Reclaimed") + "</a>";

--- a/src/static/js/incident_map.js
+++ b/src/static/js/incident_map.js
@@ -8,8 +8,13 @@ $(function() {
 
         render: function() {
             let headerheight = $("body").outerHeight() + 50;
+            let title = _("Active Incidents");
+            if (controller.name == "recent_incident_map") {
+                title = _("Recent Incidents");
+            }
+            console.log(title);
             return [
-                html.content_header(_("Active Incidents")),
+                html.content_header(title),
                 '<div id="embeddedmap" style="position: absolute;z-index: 1; width: 100%; height: calc(100% - ' + headerheight + 'px); color: #000"></div>',
                 html.content_footer()
             ].join("\n");
@@ -47,7 +52,7 @@ $(function() {
         name: "incident_map",
         animation: "results",
         title: function() {
-            if (controller.name == "incident_map") {
+            if (controller.name == "active_incident_map") {
                 return _("Active Incidents");
             } else {
                 return _("Recent Incidents");


### PR DESCRIPTION
Add a new option under the Animal Control for "Map of recent incidents". It should show pins for:

    Animals recently reclaimed (last 3 months)
    Owned non-shelter animals in the area (use city and last 12 months as filter)
    Recent incidents (last 3 months)

They'll have clickable links in their description box.

We're using a more upto date leaflet API now, see if there's an option to use different pin colours. I did find this on StackOverflow:
Image

it looks like we could add some pin styles to asm.css to have other coloured pins and incorporate that into the data we pass to the mapping functions in common_map.js