### PR TITLE
Person records: Active fosters and Owned animals rows in the banner

### DIFF
--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -92,7 +92,6 @@ def get_person(dbo: Database, personid: int) -> ResultRow:
     """
     p = dbo.first_row( dbo.query(get_person_query(dbo) + "WHERE o.ID = ?", [personid]) )
     if p is None: return None
-    p = embellish_latest_movement(dbo, p)
     p = asm3.users.embellish_vieweditroles(dbo, "ownerrole", "OwnerID", personid, p)
     return p
 
@@ -127,27 +126,6 @@ def embellish_adoption_warnings(dbo: Database, p: ResultRow) -> ResultRow:
     for r in dbo.query("SELECT AnimalID FROM adoption WHERE OwnerID=? AND MovementType=0 AND ReservationCancelledDate Is Null", [p.ID]):
         reserves.append(str(r.ANIMALID))
     p.RESERVEDANIMALIDS = ",".join(reserves)
-    return p
-
-def embellish_latest_movement(dbo: Database, p: ResultRow) -> ResultRow:
-    """ Adds the latest movement info to a person record p and returns it.
-        The query already does this and 99% of the time it will work fine and makes these columns available
-        in v_person for the query builder. BUT if we have a data import where the movements were created out of
-        order, MAX(ID) will fail and return the wrong movement. """
-    if p is None: return p
-    lm = dbo.first_row(dbo.query("SELECT m.ID AS LatestMoveAnimalID, a.ID AS LatestMoveAnimalID, a.AnimalName AS LatestMoveAnimalName, " \
-        "a.ShelterCode AS LatestMoveShelterCode, a.DeceasedDate AS LatestMoveDeceasedDate, mt.MovementType AS LatestMoveTypeName " \
-        "FROM adoption m "
-        "INNER JOIN animal a ON m.AnimalID = a.ID " \
-        "INNER JOIN lksmovementtype mt ON mt.ID = m.MovementType " \
-        "WHERE m.MovementType > 0 AND m.OwnerID = ? AND (ReturnDate Is Null OR ReturnDate > ?)" \
-        "ORDER BY m.MovementDate DESC", [p.ID, dbo.today()]))
-    if lm is not None:
-        p.LATESTMOVEANIMALID = lm.LATESTMOVEANIMALID
-        p.LATESTMOVEANIMALNAME = lm.LATESTMOVEANIMALNAME
-        p.LATESTMOVESHELTERCODE = lm.LATESTMOVESHELTERCODE
-        p.LATESTMOVEDECEASEDDATE = lm.LATESTMOVEDECEASEDDATE
-        p.LATESTMOVETYPENAME = lm.LATESTMOVETYPENAME
     return p
 
 def get_homechecked(dbo: Database, personid: int) -> Results:

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -23,7 +23,7 @@ from datetime import datetime
 ASCENDING = 0
 DESCENDING = 1
 
-def get_active_animals(dbo: Database, personid: int):
+def get_owned_animals(dbo: Database, personid: int):
     return dbo.query(
         "SELECT ad.AnimalID, an.ShelterCode, an.ShortCode, an.AnimalName, ad.MovementType AS LinkType, ad.MovementDate AS SortDate " \
         "FROM adoption ad " \

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -23,6 +23,20 @@ from datetime import datetime
 ASCENDING = 0
 DESCENDING = 1
 
+def get_active_animals(dbo: Database, personid: int):
+    return dbo.query(
+        "SELECT ad.AnimalID, an.ShelterCode, an.ShortCode, an.AnimalName, ad.MovementType AS LinkType, ad.MovementDate AS SortDate " \
+        "FROM adoption ad " \
+        "INNER JOIN animal an ON ad.AnimalID = an.ID " \
+        "WHERE ad.OwnerID = ? AND an.DeceasedDate IS NULL AND ad.ReturnDate IS NULL " \
+        "AND ad.MovementType IN (?, ?) " \
+        "UNION SELECT an.ID AS AnimalID, an.ShelterCode, an.ShortCode, an.AnimalName, 3 AS LinkType, an.CreatedDate AS SortDate " \
+        "FROM animal an " \
+        "WHERE an.DeceasedDate IS NULL AND an.NonShelterAnimal = 1 AND an.OwnerID = ? " \
+        "ORDER BY SortDate DESC",
+        (personid, asm3.movement.ADOPTION, asm3.movement.FOSTER, personid)
+    )
+
 def get_person_query(dbo: Database) -> str:
     """
     Returns the SELECT and JOIN commands necessary for selecting

--- a/src/main.py
+++ b/src/main.py
@@ -6889,6 +6889,7 @@ class person(JSONEndpoint):
         if asm3.configuration.audit_on_view_record(dbo): asm3.audit.view_record(dbo, o.user, "owner", p.ID, p.OWNERNAME)
         asm3.al.debug("opened person '%s'" % p.OWNERNAME, "main.person", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "additional": asm3.additional.get_additional_fields(dbo, p.id, "person"),
             "animalflags": asm3.lookups.get_animal_flags(dbo),
             "animaltypes": asm3.lookups.get_animal_types(dbo),

--- a/src/main.py
+++ b/src/main.py
@@ -6889,7 +6889,7 @@ class person(JSONEndpoint):
         if asm3.configuration.audit_on_view_record(dbo): asm3.audit.view_record(dbo, o.user, "owner", p.ID, p.OWNERNAME)
         asm3.al.debug("opened person '%s'" % p.OWNERNAME, "main.person", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "additional": asm3.additional.get_additional_fields(dbo, p.id, "person"),
             "animalflags": asm3.lookups.get_animal_flags(dbo),
             "animaltypes": asm3.lookups.get_animal_types(dbo),
@@ -6950,7 +6950,7 @@ class person_boarding(JSONEndpoint):
         rows = asm3.financial.get_person_boarding(dbo, p.ID)
         asm3.al.debug("got %d person boarding records" % (len(rows)), "main.person_boarding", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_boarding",
             "person": p,
             "boardingtypes": asm3.lookups.get_boarding_types(dbo),
@@ -6975,7 +6975,7 @@ class person_citations(JSONEndpoint):
         citations = asm3.financial.get_person_citations(dbo, o.post.integer("id"))
         asm3.al.debug("got %d citations" % len(citations), "main.person_citations", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_citations",
             "rows": citations,
             "person": p,
@@ -6999,7 +6999,7 @@ class person_clinic(JSONEndpoint):
         rows = asm3.clinic.get_person_appointments(dbo, personid)
         asm3.al.debug("got %d appointments for person %s" % (len(rows), p.OWNERNAME), "main.person_clinic", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": self.url,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, personid)[0],
@@ -7025,7 +7025,7 @@ class person_diary(JSONEndpoint):
         diaries = asm3.diary.get_diaries(dbo, asm3.diary.PERSON, o.post.integer("id"))
         asm3.al.debug("got %d diaries" % len(diaries), "main.person_diary", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "rows": diaries,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0],
@@ -7047,7 +7047,7 @@ class person_donations(JSONEndpoint):
         if p is None: self.notfound()
         donations = asm3.financial.get_person_donations(dbo, o.post.integer("id"))
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0],
             "name": "person_donations",
@@ -7074,7 +7074,7 @@ class person_costs(JSONEndpoint):
         costs = asm3.animal.get_costs_for_payee(dbo, personid)
         asm3.al.debug("got %d costs for person %s" % (len(costs), p["OWNERNAME"]), "main.person_costs", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_costs",
             "rows": costs,
             "person": p,
@@ -7225,7 +7225,7 @@ class person_investigation(JSONEndpoint):
         investigation = asm3.person.get_investigation(dbo, o.post.integer("id"))
         asm3.al.debug("got %d investigation records for person %s" % (len(investigation), p["OWNERNAME"]), "main.person_investigation", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "rows": investigation,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0]
@@ -7256,7 +7256,7 @@ class person_licence(JSONEndpoint):
         licences = asm3.financial.get_person_licences(dbo, o.post.integer("id"))
         asm3.al.debug("got %d licences" % len(licences), "main.person_licence", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_licence",
             "rows": licences,
             "person": p,
@@ -7279,7 +7279,7 @@ class person_log(JSONEndpoint):
         if p is None: self.notfound()
         logs = asm3.log.get_logs(dbo, asm3.log.PERSON, o.post.integer("id"), logfilter)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_log",
             "linkid": o.post.integer("id"),
             "linktypeid": asm3.log.PERSON,
@@ -7312,7 +7312,7 @@ class person_links(JSONEndpoint):
         if p is None: self.notfound()
         asm3.al.debug("got %d person links" % len(links), "main.person_links", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "links": links,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0]
@@ -7330,7 +7330,7 @@ class person_media(JSONEndpoint):
         m = asm3.media.get_media(dbo, asm3.media.PERSON, o.post.integer("id"))
         asm3.al.debug("got %d media" % len(m), "main.person_media", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "media": m,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0],
@@ -7362,7 +7362,7 @@ class person_movements(JSONEndpoint):
         movements = asm3.person.reduce_find_results(dbo, o.user, movements, idcol="OWNERID", sitecol="OWNERSITEID")
         asm3.al.debug("got %d movements" % len(movements), "main.person_movements", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_movements",
             "rows": movements,
             "person": p,
@@ -7412,7 +7412,7 @@ class person_rota(JSONEndpoint):
         rota = asm3.person.get_person_rota(dbo, o.post.integer("id"))
         asm3.al.debug("got %d rota items" % len(rota), "main.person_rota", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_rota",
             "rows": rota,
             "person": p,
@@ -7446,7 +7446,7 @@ class person_traploan(JSONEndpoint):
         traploans = asm3.animalcontrol.get_person_traploans(dbo, o.post.integer("id"))
         asm3.al.debug("got %d trap loans" % len(traploans), "main.person_traploan", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_traploan",
             "rows": traploans,
             "person": p,
@@ -7466,7 +7466,7 @@ class person_vouchers(JSONEndpoint):
         vouchers = asm3.financial.get_person_vouchers(dbo, o.post.integer("id"))
         asm3.al.debug("got %d person vouchers" % len(vouchers), "main.person_vouchers", dbo)
         return {
-            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
+            "activeanimals": asm3.person.get_owned_animals(dbo, p.id),
             "name": "person_vouchers",
             "rows": vouchers,
             "person": p,

--- a/src/main.py
+++ b/src/main.py
@@ -6950,6 +6950,7 @@ class person_boarding(JSONEndpoint):
         rows = asm3.financial.get_person_boarding(dbo, p.ID)
         asm3.al.debug("got %d person boarding records" % (len(rows)), "main.person_boarding", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_boarding",
             "person": p,
             "boardingtypes": asm3.lookups.get_boarding_types(dbo),
@@ -6974,6 +6975,7 @@ class person_citations(JSONEndpoint):
         citations = asm3.financial.get_person_citations(dbo, o.post.integer("id"))
         asm3.al.debug("got %d citations" % len(citations), "main.person_citations", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_citations",
             "rows": citations,
             "person": p,
@@ -6997,6 +6999,7 @@ class person_clinic(JSONEndpoint):
         rows = asm3.clinic.get_person_appointments(dbo, personid)
         asm3.al.debug("got %d appointments for person %s" % (len(rows), p.OWNERNAME), "main.person_clinic", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": self.url,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, personid)[0],
@@ -7022,6 +7025,7 @@ class person_diary(JSONEndpoint):
         diaries = asm3.diary.get_diaries(dbo, asm3.diary.PERSON, o.post.integer("id"))
         asm3.al.debug("got %d diaries" % len(diaries), "main.person_diary", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "rows": diaries,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0],
@@ -7043,6 +7047,7 @@ class person_donations(JSONEndpoint):
         if p is None: self.notfound()
         donations = asm3.financial.get_person_donations(dbo, o.post.integer("id"))
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0],
             "name": "person_donations",
@@ -7069,6 +7074,7 @@ class person_costs(JSONEndpoint):
         costs = asm3.animal.get_costs_for_payee(dbo, personid)
         asm3.al.debug("got %d costs for person %s" % (len(costs), p["OWNERNAME"]), "main.person_costs", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_costs",
             "rows": costs,
             "person": p,
@@ -7219,6 +7225,7 @@ class person_investigation(JSONEndpoint):
         investigation = asm3.person.get_investigation(dbo, o.post.integer("id"))
         asm3.al.debug("got %d investigation records for person %s" % (len(investigation), p["OWNERNAME"]), "main.person_investigation", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "rows": investigation,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0]
@@ -7249,6 +7256,7 @@ class person_licence(JSONEndpoint):
         licences = asm3.financial.get_person_licences(dbo, o.post.integer("id"))
         asm3.al.debug("got %d licences" % len(licences), "main.person_licence", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_licence",
             "rows": licences,
             "person": p,
@@ -7271,6 +7279,7 @@ class person_log(JSONEndpoint):
         if p is None: self.notfound()
         logs = asm3.log.get_logs(dbo, asm3.log.PERSON, o.post.integer("id"), logfilter)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_log",
             "linkid": o.post.integer("id"),
             "linktypeid": asm3.log.PERSON,
@@ -7303,6 +7312,7 @@ class person_links(JSONEndpoint):
         if p is None: self.notfound()
         asm3.al.debug("got %d person links" % len(links), "main.person_links", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "links": links,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0]
@@ -7320,6 +7330,7 @@ class person_media(JSONEndpoint):
         m = asm3.media.get_media(dbo, asm3.media.PERSON, o.post.integer("id"))
         asm3.al.debug("got %d media" % len(m), "main.person_media", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "media": m,
             "person": p,
             "tabcounts": asm3.person.get_satellite_counts(dbo, p["ID"])[0],
@@ -7351,6 +7362,7 @@ class person_movements(JSONEndpoint):
         movements = asm3.person.reduce_find_results(dbo, o.user, movements, idcol="OWNERID", sitecol="OWNERSITEID")
         asm3.al.debug("got %d movements" % len(movements), "main.person_movements", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_movements",
             "rows": movements,
             "person": p,
@@ -7400,6 +7412,7 @@ class person_rota(JSONEndpoint):
         rota = asm3.person.get_person_rota(dbo, o.post.integer("id"))
         asm3.al.debug("got %d rota items" % len(rota), "main.person_rota", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_rota",
             "rows": rota,
             "person": p,
@@ -7433,6 +7446,7 @@ class person_traploan(JSONEndpoint):
         traploans = asm3.animalcontrol.get_person_traploans(dbo, o.post.integer("id"))
         asm3.al.debug("got %d trap loans" % len(traploans), "main.person_traploan", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_traploan",
             "rows": traploans,
             "person": p,
@@ -7452,6 +7466,7 @@ class person_vouchers(JSONEndpoint):
         vouchers = asm3.financial.get_person_vouchers(dbo, o.post.integer("id"))
         asm3.al.debug("got %d person vouchers" % len(vouchers), "main.person_vouchers", dbo)
         return {
+            "activeanimals": asm3.person.get_active_animals(dbo, p.id),
             "name": "person_vouchers",
             "rows": vouchers,
             "person": p,

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -603,7 +603,7 @@ edit_header = {
             fostershtml = '<tr><td>' + _("Active Fosters") + ':</td>';
         }
         if (fosters.length > 5) {
-            fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (fosters.length - 1) + ' more...</a></b></td></tr>';
+            fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (fosters.length - 1) + ' ' + _("more...") + '</a></b></td></tr>';
         } else {
             fostershtml += '<td>';
             let fosterlinks = [];
@@ -617,7 +617,7 @@ edit_header = {
             ownedanimalshtml = '<tr><td>' + _("Owned Animals") + ':</td>';
         }
         if (ownedanimals.length > 5) {
-            ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (ownedanimals.length - 1) + ' more...</a></b></td></tr>';
+            ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (ownedanimals.length - 1) + ' ' + _("more...") + '</a></b></td></tr>';
         } else {
             ownedanimalshtml += '<td>';
             let ownedanimallinks = [];

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -603,12 +603,13 @@ edit_header = {
             fostershtml = '<tr><td>' + _("Active Fosters") + ':</td>';
         }
         if (fosters.length > 5) {
-            fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (fosters.length - 1)) + '</a></b></td></tr>';
+            // fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (fosters.length - 1)) + '</a></b></td></tr>';
+            fostershtml += '<td><a href="person_movements?id=' + controller.person.ID + '">' + _("{0} plus {1} more...").replace("{0}", fosters[0].ANIMALNAME).replace("{1}",  (fosters.length - 1)) + '</a></td></tr>';
         } else {
             fostershtml += '<td>';
             let fosterlinks = [];
             $.each(fosters, function(i, v) {
-                fosterlinks.push('<b><a href="animal?id=' + v.ANIMALID + '">' + v.ANIMALNAME + '</a></b>');
+                fosterlinks.push('<a href="animal?id=' + v.ANIMALID + '">' + v.ANIMALNAME + '</a>');
             });
             fostershtml += fosterlinks.join(", ");
             fostershtml += '</td></tr>';
@@ -617,12 +618,13 @@ edit_header = {
             ownedanimalshtml = '<tr><td>' + _("Owned Animals") + ':</td>';
         }
         if (ownedanimals.length > 5) {
-            ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (ownedanimals.length - 1)) + '</a></b></td></tr>';
+            // ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (ownedanimals.length - 1)) + '</a></b></td></tr>';
+            ownedanimalshtml += '<td><a href="person_movements?id=' + controller.person.ID + '">' + _("{0} plus {1} more...").replace("{0}", ownedanimals[0].ANIMALNAME).replace("{1}",  (ownedanimals.length - 1)) + '</a></td></tr>';
         } else {
             ownedanimalshtml += '<td>';
             let ownedanimallinks = [];
             $.each(ownedanimals, function(i, v) {
-                ownedanimallinks.push('<b><a href="animal?id=' + v.ANIMALID + '">' + v.ANIMALNAME + '</a></b>');
+                ownedanimallinks.push('<a href="animal?id=' + v.ANIMALID + '">' + v.ANIMALNAME + '</a>');
             });
             ownedanimalshtml += ownedanimallinks.join(", ");
             ownedanimalshtml += '</td></tr>';

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -595,6 +595,45 @@ edit_header = {
             latestmove += "<td><b>" + p.LATESTMOVETYPENAME + " " + html.icon("right") + " ";
             latestmove += '<a href="animal?id=' + p.LATESTMOVEANIMALID + '">' + p.LATESTMOVEANIMALNAME + '</a></b> ' + latestmovedeceased + '</td></tr>';
         }
+        let fosters = [];
+        let ownedanimals = [];
+        $.each(controller.activeanimals, function(i, v) {
+            if (v.LINKTYPE == 2) {
+                fosters.push(v);
+            } else {
+                ownedanimals.push(v);
+            }
+        });
+        let fostershtml = "";
+        let ownedanimalshtml = "";
+        if (fosters.length) {
+            fostershtml = '<tr><td>' + _("Active Fosters") + ':</td>';
+        }
+        if (fosters.length > 5) {
+            fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (fosters.length - 1) + ' more...</a></b></td></tr>';
+        } else {
+            fostershtml += '<td>';
+            let fosterlinks = [];
+            $.each(fosters, function(i, v) {
+                fosterlinks.push('<b><a href="animal?id=' + v.ANIMALID + '">' + v.ANIMALNAME + '</a></b>');
+            });
+            fostershtml += fosterlinks.join(", ");
+            fostershtml += '</td></tr>';
+        }
+        if (ownedanimals.length) {
+            ownedanimalshtml = '<tr><td>' + _("Owned Animals") + ':</td>';
+        }
+        if (ownedanimals.length > 5) {
+            ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (ownedanimals.length - 1) + ' more...</a></b></td></tr>';
+        } else {
+            ownedanimalshtml += '<td>';
+            let ownedanimallinks = [];
+            $.each(ownedanimals, function(i, v) {
+                ownedanimallinks.push('<b><a href="animal?id=' + v.ANIMALID + '">' + v.ANIMALNAME + '</a></b>');
+            });
+            ownedanimalshtml += ownedanimallinks.join(", ");
+            ownedanimalshtml += '</td></tr>';
+        }
         let s = [
             '<div class="asm-banner ui-helper-reset ui-widget-content ui-corner-all">',
             '<input type="hidden" id="personid" value="' + p.ID + '" />',
@@ -616,6 +655,8 @@ edit_header = {
             '<div class="col-sm">',
             '<table>',
             latestmove,
+            fostershtml,
+            ownedanimalshtml,
             '<tr>',
             '<td></td><td>' + p.OWNERADDRESS + '<br />',
             p.OWNERTOWN + ' ' + p.OWNERCOUNTY + ' ' + p.OWNERPOSTCODE + '<br />',

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -603,7 +603,8 @@ edit_header = {
             fostershtml = '<tr><td>' + _("Active Fosters") + ':</td>';
         }
         if (fosters.length > 5) {
-            fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (fosters.length - 1) + ' ' + _("more...") + '</a></b></td></tr>';
+            // fostershtml += '<td><a href="person_movements?id=' + controller.person.ID + '">' + _("{0} plus {1} more...").replace("{0}", fosters[0].ANIMALNAME).replace("{1}",  (fosters.length - 1)) + '</a></td></tr>';
+            fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (fosters.length - 1)) + '</a></b></td></tr>';
         } else {
             fostershtml += '<td>';
             let fosterlinks = [];
@@ -617,7 +618,7 @@ edit_header = {
             ownedanimalshtml = '<tr><td>' + _("Owned Animals") + ':</td>';
         }
         if (ownedanimals.length > 5) {
-            ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> plus <a href="person_movements?id=' + controller.person.ID + '">' + (ownedanimals.length - 1) + ' ' + _("more...") + '</a></b></td></tr>';
+            ownedanimalshtml += '<td><b><a href="animal?id=' + ownedanimals[0].ANIMALID + '">' + ownedanimals[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (ownedanimals.length - 1)) + '</a></b></td></tr>';
         } else {
             ownedanimalshtml += '<td>';
             let ownedanimallinks = [];

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -603,7 +603,6 @@ edit_header = {
             fostershtml = '<tr><td>' + _("Active Fosters") + ':</td>';
         }
         if (fosters.length > 5) {
-            // fostershtml += '<td><a href="person_movements?id=' + controller.person.ID + '">' + _("{0} plus {1} more...").replace("{0}", fosters[0].ANIMALNAME).replace("{1}",  (fosters.length - 1)) + '</a></td></tr>';
             fostershtml += '<td><b><a href="animal?id=' + fosters[0].ANIMALID + '">' + fosters[0].ANIMALNAME + '</a> <a href="person_movements?id=' + controller.person.ID + '">' + _("plus {0} more...").replace("{0}",  (fosters.length - 1)) + '</a></b></td></tr>';
         } else {
             fostershtml += '<td>';

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -588,13 +588,6 @@ edit_header = {
             return html.icon("blank");
         };
         let flags = this.person_flags(p);
-        let latestmove = "", latestmovedeceased = "";
-        if (p.LATESTMOVEANIMALID) { 
-            if (p.LATESTMOVEDECEASEDDATE) { latestmovedeceased = html.icon("death"); }
-            latestmove = "<tr><td>" + _("Last Movement") + ":</td>";
-            latestmove += "<td><b>" + p.LATESTMOVETYPENAME + " " + html.icon("right") + " ";
-            latestmove += '<a href="animal?id=' + p.LATESTMOVEANIMALID + '">' + p.LATESTMOVEANIMALNAME + '</a></b> ' + latestmovedeceased + '</td></tr>';
-        }
         let fosters = [];
         let ownedanimals = [];
         $.each(controller.activeanimals, function(i, v) {
@@ -654,7 +647,6 @@ edit_header = {
             '</div>',
             '<div class="col-sm">',
             '<table>',
-            latestmove,
             fostershtml,
             ownedanimalshtml,
             '<tr>',


### PR DESCRIPTION
A user was asking about the last movement shown in the banner currently. They were trying to make it skip the latest if it was deceased. Digging into what they actually want, they'd like animals that are being actively fostered by that person to appear in the banner.

I suggested a row for owned animals as well, as it would be convenient when viewing people with non-shelter animals in particular.

So, rows in the banner for both, but they only appear if there is active data for them.

I think trying to add this info to get_person_query would heavily impact performance for searching and in other unnecessary areas that use person query.

If we are going to do it, we should make this a function in person.py/get_active_animals(personid: int), it should use a UNION query to return a resultset of AnimalID, ShelterCode, ShortCode, AnimalName, LinkType animals connected to this person. LinkType is an int to indicate the relationship to the person. Use 1 for adopter (ie. person is on an open adoption movement for that animal), 2 for fosterer and 3 for owner.

This function can then be called in all of the person/person_x endpoints and the data returned in the controller so that person_edit_header can access it and output the animal links in the new banner rows described above.

The two new rows can replace the last movement row in the banner. Assuming nothing else is using those fields (and it doesn't look like it), the latestmoveanimal/latestfoster columns can be removed from get_person_query.