### PR TITLE
Update the renewal column in ownerlicence when the new licence is of a different type to previous

### DIFF
--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -394,6 +394,7 @@ DEFAULTS = {
     "ReloadMedical": "Yes",
     "ReportToolbar": "Yes",
     "ReservesOverdueDays": "7",
+    "RestrictLicenseRenewal": "No",
     "RetailerOnShelter": "Yes",
     "ReturnFostersOnAdoption": "Yes",
     "ReturnFostersOnTransfer": "Yes",
@@ -1695,6 +1696,9 @@ def rescuegroups_password(dbo: Database) -> str:
 
 def resize_images_spec(dbo: Database) -> str:
     return cstring(dbo, "ResizeImagesSpec")
+
+def restrict_license_renewal(dbo: Database) -> bool:
+    return cboolean(dbo, "RestrictLicenseRenewal", DEFAULTS["RestrictLicenseRenewal"] == "Yes")
 
 def retailer_on_shelter(dbo: Database) -> bool:
     return cboolean(dbo, "RetailerOnShelter", DEFAULTS["RetailerOnShelter"] == "Yes")

--- a/src/asm3/financial.py
+++ b/src/asm3/financial.py
@@ -1723,14 +1723,22 @@ def update_licence_renewed(dbo: Database, username: str, typeid: int, personid: 
     """
     Finds all licences that match the given triplet of typeid, personid and animalid 
     and marks all but the one with the latest issuedate as renewed.
+    If the RestrictLicenseRenewal option is enabled, typeid is ignored.
     Returns the number of affected rows.
     If the animalid or personid is 0 does nothing. By doing this, records that are 
     not linked to animal allow their renewed flag to be edited.
     """
     if animalid == 0 or personid == 0: return 0
-    rows = dbo.query("SELECT ID, AnimalID, OwnerID, IssueDate, Renewed FROM ownerlicence " \
-        "WHERE LicenceTypeID=? AND OwnerID=? AND AnimalID=? ORDER BY IssueDate DESC", \
+
+    if asm3.configuration.restrict_license_renewal(dbo):
+        rows = dbo.query("SELECT ID, AnimalID, OwnerID, IssueDate, Renewed FROM ownerlicence " \
+        "WHERE LicenceTypeID=? AND OwnerID=? AND AnimalID=? ORDER BY IssueDate DESC",
         [ typeid, personid, animalid ])
+    else:
+        rows = dbo.query("SELECT ID, AnimalID, OwnerID, IssueDate, Renewed FROM ownerlicence " \
+        "WHERE OwnerID=? AND AnimalID=? ORDER BY IssueDate DESC",
+        [ personid, animalid ])
+    
     if len(rows) == 0: return 0
     for i, r in enumerate(rows):
         renewed = 1

--- a/src/static/js/licence.js
+++ b/src/static/js/licence.js
@@ -136,6 +136,9 @@ $(function() {
                                     controller.rows.push(row);
                                     tableform.table_update(table);
                                     tableform.dialog_close();
+                                    if (!common.current_url().includes("/licence")) {
+                                        common.route_reload();
+                                    }
                                 }
                                 finally {
                                     tableform.dialog_enable_buttons();
@@ -173,9 +176,13 @@ $(function() {
                                     controller.rows.push(row);
                                     tableform.table_update(table);
                                     tableform.dialog_close();
+                                    if (!common.current_url().includes("/licence")) {
+                                        common.route_reload();
+                                    }
                                 }
                                 finally {
                                     tableform.dialog_enable_buttons();
+                                    
                                 }
                             },
                             onload: function() {
@@ -199,6 +206,9 @@ $(function() {
                         tableform.buttons_default_state(buttons);
                         let ids = tableform.table_ids(table);
                         await common.ajax_post("licence", "mode=delete&ids=" + ids);
+                        if (!common.current_url().includes("/licence")) {
+                            common.route_reload();
+                        }
                         tableform.table_remove_selected_from_json(table, controller.rows);
                         tableform.table_update(table);
                     }

--- a/src/static/js/licence.js
+++ b/src/static/js/licence.js
@@ -136,7 +136,7 @@ $(function() {
                                     controller.rows.push(row);
                                     tableform.table_update(table);
                                     tableform.dialog_close();
-                                    if (!common.current_url().includes("/licence")) {
+                                    if (controller.name != 'licence') {
                                         common.route_reload();
                                     }
                                 }
@@ -176,7 +176,7 @@ $(function() {
                                     controller.rows.push(row);
                                     tableform.table_update(table);
                                     tableform.dialog_close();
-                                    if (!common.current_url().includes("/licence")) {
+                                    if (controller.name != 'licence') {
                                         common.route_reload();
                                     }
                                 }
@@ -206,7 +206,7 @@ $(function() {
                         tableform.buttons_default_state(buttons);
                         let ids = tableform.table_ids(table);
                         await common.ajax_post("licence", "mode=delete&ids=" + ids);
-                        if (!common.current_url().includes("/licence")) {
+                        if (controller.name != 'licence') {
                             common.route_reload();
                         }
                         tableform.table_remove_selected_from_json(table, controller.rows);

--- a/src/static/js/options.js
+++ b/src/static/js/options.js
@@ -397,6 +397,9 @@ $(function() {
                          { id: "duplicatechip", post_field: "AllowDuplicateMicrochip", label: _("Allow duplicate microchip numbers"), type: "check", fullrow: true },
                          { id: "uniquelicence", post_field: "rc:UniqueLicenceNumbers", label: _("Allow duplicate license numbers"), type: "check", fullrow: true }
                     ]},
+                    { id: "tab-animalcontrol", title: _("Animal Control"), fields: [
+                          { id: "restrictlicenserenewal", post_field: "RestrictLicenseRenewal", label: _("Only allow licenses to renew licenses of the same type"), type: "check" }
+                    ]},
                     { id: "tab-animalemblems", title: _("Animal Emblems"), fields: [
                         { type: "raw", markup: html.textbar(_("Animal emblems are the little icons that appear next to animal names in shelter view, the home page and search results."), {maxwidth: "470px"}) },
                         { id: "alwaysshowlocation", post_field: "EmblemAlwaysLocation", type: "check", 

--- a/src/static/js/options.js
+++ b/src/static/js/options.js
@@ -394,11 +394,12 @@ $(function() {
                          { id: "disableshortcodes", post_field: "DisableShortCodesControl", label: _("Remove short shelter code box from the animal details screen"), type: "check", fullrow: true },
                          { id: "shelterviewshowcodes", post_field: "ShelterViewShowCodes", label: _("Show codes on the shelter view screen"), type: "check", fullrow: true },
                          { id: "lockcodes", post_field: "LockCodes", label: _("Once assigned, codes cannot be changed"), type: "check", fullrow: true },
-                         { id: "duplicatechip", post_field: "AllowDuplicateMicrochip", label: _("Allow duplicate microchip numbers"), type: "check", fullrow: true },
-                         { id: "uniquelicence", post_field: "rc:UniqueLicenceNumbers", label: _("Allow duplicate license numbers"), type: "check", fullrow: true }
+                         { id: "duplicatechip", post_field: "AllowDuplicateMicrochip", label: _("Allow duplicate microchip numbers"), type: "check", fullrow: true }
                     ]},
                     { id: "tab-animalcontrol", title: _("Animal Control"), fields: [
-                          { id: "restrictlicenserenewal", post_field: "RestrictLicenseRenewal", label: _("Only allow licenses to renew licenses of the same type"), type: "check" }
+                        { id: "uniquelicence", post_field: "rc:UniqueLicenceNumbers", label: _("Allow duplicate license numbers"), type: "check", fullrow: true },
+                        { id: "restrictlicenserenewal", post_field: "RestrictLicenseRenewal", label: _("Only allow licenses to renew licenses of the same type"), type: "check", fullrow: true }
+                          
                     ]},
                     { id: "tab-animalemblems", title: _("Animal Emblems"), fields: [
                         { type: "raw", markup: html.textbar(_("Animal emblems are the little icons that appear next to animal names in shelter view, the home page and search results."), {maxwidth: "470px"}) },


### PR DESCRIPTION
This is not a bug. In this scenario, the organisation is using licencing for dog licences (which many people do). However, there are other types of licences that can't just be renewed by "any" licence.

Since it is the most common circumstance of use, what I suggest we do is add a new option under a new "Animal Control" tab for "Only allow licenses to renew licenses of the same type" and make it unchecked by default. This makes the new option effectively the default, but people can turn this on to enable the old behaviour if they want.