### PR TITLE
add python3-lxml to list of required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ install all the software you need to run ASM. If you are using the
 sheltermanager3 deb package it already has dependencies set for these and will
 install them for you.
 
-* apt-get install make python3 python3-cheroot python3-pil python3-mysqldb python3-psycopg2 python3-memcache
+* apt-get install make python3 python3-cheroot python3-pil python3-mysqldb python3-psycopg2 python3-memcache python3-lxml
 
 Extra, non-mandatory packages:
 


### PR DESCRIPTION
First off, an introduction!

Hi! My name is Lee, I'm a professional software developer (just hit 7 years of industry experience this month, wow)! Today I volunteered at a cat shelter for the first time and they set me up with access to their shelter manager instance, I was curious about the website and was excited to find out it's open source and figured I could volunteer my time in another way, too!

While setting up the project locally, I wasn't able to get it started until I installed `python3-lxml`, so this adds it to the README.

Nice to meet you all, please feel free to point me towards any smaller outstanding issues that might be a good first bit for me to tackle, otherwise I'm going to get it running locally, play with it, and see if I can break anything >:) 