### PR TITLE
persist bulk vaccination animal selection on submission

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8708,9 +8708,12 @@ class vaccination(JSONEndpoint):
 
     def post_createbulk(self, o):
         self.check(asm3.users.ADD_VACCINATION)
+        resultlist = []
         for animalid in o.post.integer_list("animals"):
             o.post.data["animal"] = str(animalid)
-            asm3.medical.insert_vaccination_from_form(o.dbo, o.user, o.post)
+            result = asm3.medical.insert_vaccination_from_form(o.dbo, o.user, o.post)
+            resultlist.append(result)
+        return resultlist
 
     def post_update(self, o):
         self.check(asm3.users.CHANGE_VACCINATION)

--- a/src/static/js/common_animalchoosermulti.js
+++ b/src/static/js/common_animalchoosermulti.js
@@ -193,13 +193,16 @@ $.fn.animalchoosermulti = asm_widget({
     select: function(t) {
         let self = this, o = t.data("o"), selval = [];
         o.display.html("");
+        let animals = [];
         o.results.find(":checked").each(function() {
             let aid = $(this).attr("data"), rec = self.get_row(t, aid);
             selval.push(aid);
             let disp = "<a class=\"asm-embed-name\" href=\"animal?id=" + rec.ID + "\">" + rec.CODE + " - " + rec.ANIMALNAME + "</a>";
+            animals.push(rec);
             o.display.append(disp);
             o.display.append("<br />");
         });
+        sessionStorage.setItem("last_multi_animals", JSON.stringify(animals));
         t.val(selval.join(","));
         t.trigger("change", [ t.val() ]);
         o.dialog.dialog("close");

--- a/src/static/js/vaccination.js
+++ b/src/static/js/vaccination.js
@@ -344,7 +344,7 @@ $(function() {
         },
 
         new_bulk_vacc: function() {
-            let dialog = vaccination.dialog;
+            let dialog = vaccination.dialog, table = vaccination.table;
             tableform.dialog_show_add(dialog, {
                 onvalidate: function() {
                     return validate.notblank([ "animals" ]);
@@ -352,20 +352,33 @@ $(function() {
                 onadd: async function() {
                     try {
                         await tableform.fields_post(dialog.fields, "mode=createbulk", "vaccination");
-                        tableform.dialog_close();
-                        common.route_reload();
+                        let chosenanimalsstring = sessionStorage.getItem("last_multi_animals");
+                        let chosenanimals = JSON.parse(chosenanimalsstring);
+                        let chosentype = $("#type option:selected").text() 
+                        chosenanimals.forEach(animal => {
+                            animal.VACCINATIONTYPE = chosentype;
+                            tableform.fields_update_row(dialog.fields, animal);
+                            controller.rows.push(animal);
+                        })
+                        tableform.table_update(table);
+                        tableform.dialog_enable_buttons();
+                        // tableform.dialog_close();
                     }
                     catch(err) {
                         log.error(err, err);
                         tableform.dialog_enable_buttons();   
                     }
                 },
+                oncancel: async function() {
+                    sessionStorage.removeItem("last_multi_animals");
+                },
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    $("#animals").animalchoosermulti("clear");
                     $("#dialog-tableform .asm-textbox, #dialog-tableform .asm-textarea").val("");
                     $("#type").select("value", config.str("AFDefaultVaccinationType"));
+                    $("#animals").animalchoosermulti("clear");
+                    sessionStorage.removeItem("last_multi_animals");
                     vaccination.enable_default_cost = true;
                     vaccination.set_default_cost();
                 }
@@ -602,6 +615,8 @@ $(function() {
                 row.SHELTERCODE = vaccination.lastanimal.SHELTERCODE;
                 row.SHORTCODE = vaccination.lastanimal.SHORTCODE;
                 row.WEBSITEMEDIANAME = vaccination.lastanimal.WEBSITEMEDIANAME;
+                row.SPECIESNAME = vaccination.lastanimal.SPECIESNAME;
+                row.GIVENBY = vaccination.lastanimal.GIVENBY;
             }
             row.ADMINISTERINGVETNAME = "";
             if (row.ADMINISTERINGVETID && vaccination.lastvet) { row.ADMINISTERINGVETNAME = vaccination.lastvet.OWNERNAME; }

--- a/src/static/js/vaccination.js
+++ b/src/static/js/vaccination.js
@@ -362,7 +362,6 @@ $(function() {
                         })
                         tableform.table_update(table);
                         tableform.dialog_enable_buttons();
-                        // tableform.dialog_close();
                     }
                     catch(err) {
                         log.error(err, err);


### PR DESCRIPTION
Demo: https://www.loom.com/share/e737aa754b834881a2a770b720a70cbe

- Use session storage to save selected animals from multichooser to add to vaccination table on form submission
- Do not clear or close bulk vaccination form until the user clicks "cancel" 
- Add Species-Name and Given-By to table on single animal vaccination submission
- Return IDs in backend `createBulk` endpoint to match functionality of non-bulk endpoint

Not a lot of lines, but quite a bit of effort 