### PR TITLE
persistence bulk validation (take 2)!

### DIFF
--- a/src/static/js/common_animalchoosermulti.js
+++ b/src/static/js/common_animalchoosermulti.js
@@ -131,6 +131,8 @@ $.fn.animalchoosermulti = asm_widget({
         o.results.find(":checked").prop("checked", false);
         this.update_status(t);
         if (fireclearedevent) { t.trigger("cleared"); }
+
+        // Used by bulk-selection persistence regardless of fireclearedevent
         t.trigger("bulk_clear");
     },
 

--- a/src/static/js/common_animalchoosermulti.js
+++ b/src/static/js/common_animalchoosermulti.js
@@ -164,6 +164,10 @@ $.fn.animalchoosermulti = asm_widget({
         return t.data("o").rows;
     }, 
 
+    set_rows: function(t, newrows) {
+        t.data("o").rows = newrows;
+    },
+
     get_selected_rows: function(t) {
         let rows = [];
         let self = this;
@@ -192,6 +196,7 @@ $.fn.animalchoosermulti = asm_widget({
      */
     select: function(t) {
         let self = this, o = t.data("o"), selval = [];
+        console.log(self.get_rows(t));
         o.display.html("");
         o.results.find(":checked").each(function() {
             let aid = $(this).attr("data"), rec = self.get_row(t, aid);
@@ -378,6 +383,7 @@ $.fn.animalchoosermulti = asm_widget({
         let o = t.data("o");
         o.display.html("");
         $.each(newval.split(","), function(i, v) {
+            console.log(v);
             let rec = self.get_row(t, parseInt(v));
             let disp = "<a class=\"asm-embed-name\" href=\"animal?id=" + rec.ID + "\">" + rec.CODE + " - " + rec.ANIMALNAME + "</a>";
             o.display.append(disp);

--- a/src/static/js/common_animalchoosermulti.js
+++ b/src/static/js/common_animalchoosermulti.js
@@ -131,6 +131,7 @@ $.fn.animalchoosermulti = asm_widget({
         o.results.find(":checked").prop("checked", false);
         this.update_status(t);
         if (fireclearedevent) { t.trigger("cleared"); }
+        t.trigger("bulk_clear");
     },
 
     is_empty: function(t) {
@@ -196,7 +197,6 @@ $.fn.animalchoosermulti = asm_widget({
      */
     select: function(t) {
         let self = this, o = t.data("o"), selval = [];
-        console.log(self.get_rows(t));
         o.display.html("");
         o.results.find(":checked").each(function() {
             let aid = $(this).attr("data"), rec = self.get_row(t, aid);
@@ -383,7 +383,6 @@ $.fn.animalchoosermulti = asm_widget({
         let o = t.data("o");
         o.display.html("");
         $.each(newval.split(","), function(i, v) {
-            console.log(v);
             let rec = self.get_row(t, parseInt(v));
             let disp = "<a class=\"asm-embed-name\" href=\"animal?id=" + rec.ID + "\">" + rec.CODE + " - " + rec.ANIMALNAME + "</a>";
             o.display.append(disp);

--- a/src/static/js/medical.js
+++ b/src/static/js/medical.js
@@ -620,14 +620,14 @@ $(function() {
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    if (medical.lastanimalsrows != null) {
+                    if (medical.lastanimalsrows != null && medical.lastanimals != null) {
                         $("#animals").animalchoosermulti("set_rows", medical.lastanimalsrows);
                         $("#animals").animalchoosermulti("value", medical.lastanimals);
                     }
                     $("#profileidrow").show();
                     $("#treatmentrulecalc").show();
                     $("#status").select("value", "0");
-                }
+                },
             });
         },
 
@@ -936,6 +936,11 @@ $(function() {
             $("#timingrulenofrequencies").change(medical.change_values);
             $("#treatmentrule").change(medical.change_values);
             $("#totalnumberoftreatments").change(medical.change_values);
+
+            $("#animals").on("bulk_clear", function(event, rec) {
+                medical.lastanimals = null;
+                medical.lastanimalsrows = null;
+            });
 
             // Add click handlers to templates
             $(".templatelink").click(function() {

--- a/src/static/js/medical.js
+++ b/src/static/js/medical.js
@@ -87,6 +87,7 @@ $(function() {
                 edit_title: _("Edit medical regimen"),
                 edit_perm: 'mcam',
                 close_on_ok: false,
+                use_default_values: false,
                 hide_read_only: true,
                 columns: 1,
                 width: 800,

--- a/src/static/js/medical.js
+++ b/src/static/js/medical.js
@@ -628,7 +628,7 @@ $(function() {
                     $("#profileidrow").show();
                     $("#treatmentrulecalc").show();
                     $("#status").select("value", "0");
-                },
+                }
             });
         },
 

--- a/src/static/js/medical.js
+++ b/src/static/js/medical.js
@@ -7,6 +7,8 @@ $(function() {
     const medical = {
 
         lastanimal: null,
+        lastanimals: null,
+        lastanimalsrows: null,
         TREATMENT_SINGLE: 0,
         TREATMENT_MULTI: 1,
         TREATMENT_CUSTOM: 2,
@@ -603,6 +605,8 @@ $(function() {
                     return validate.notblank([ "animals" ]);
                 },
                 onadd: async function() {
+                    medical.lastanimals = $("#animals").animalchoosermulti("value");
+                    medical.lastanimalsrows = $("#animals").animalchoosermulti("get_rows");
                     try {
                         await tableform.fields_post(medical.dialog.fields, "mode=createbulk", "medical");
                         tableform.dialog_close();
@@ -616,7 +620,10 @@ $(function() {
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    $("#animals").animalchoosermulti("clear");
+                    if (medical.lastanimalsrows != null) {
+                        $("#animals").animalchoosermulti("set_rows", medical.lastanimalsrows);
+                        $("#animals").animalchoosermulti("value", medical.lastanimals);
+                    }
                     $("#profileidrow").show();
                     $("#treatmentrulecalc").show();
                     $("#status").select("value", "0");

--- a/src/static/js/test.js
+++ b/src/static/js/test.js
@@ -7,6 +7,8 @@ $(function() {
     const test = {
 
         lastanimal: null,
+        lastanimals: null,
+        lastanimalsrows: null,
         lastvet: null,
 
         model: function() {
@@ -272,6 +274,8 @@ $(function() {
                     return validate.notblank([ "animals" ]);
                 },
                 onadd: async function() {
+                    test.lastanimals = $("#animals").animalchoosermulti("value");
+                    test.lastanimalsrows = $("#animals").animalchoosermulti("get_rows");
                     try {
                         await tableform.fields_post(dialog.fields, "mode=createbulk", "test");
                         tableform.dialog_close();
@@ -285,7 +289,10 @@ $(function() {
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    $("#animals").animalchoosermulti("clear");
+                    if (test.lastanimalsrows != null) {
+                        $("#animals").animalchoosermulti("set_rows", test.lastanimalsrows);
+                        $("#animals").animalchoosermulti("value", test.lastanimals);
+                    }
                     $("#dialog-tableform .asm-textbox, #dialog-tableform .asm-textarea").val("");
                     $("#type").select("value", config.str("AFDefaultTestType"));
                     test.enable_default_cost = true;

--- a/src/static/js/test.js
+++ b/src/static/js/test.js
@@ -289,7 +289,7 @@ $(function() {
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    if (test.lastanimalsrows != null) {
+                    if (test.lastanimalsrows != null && test.lastanimals != null) {
                         $("#animals").animalchoosermulti("set_rows", test.lastanimalsrows);
                         $("#animals").animalchoosermulti("value", test.lastanimals);
                     }
@@ -398,6 +398,11 @@ $(function() {
             // Same for the vet
             $("#administeringvet").on("change loaded", function(event, rec) { test.lastvet = rec; });
             $("#givenvet").on("change loaded", function(event, rec) { test.lastvet = rec; });
+
+            $("#animals").on("bulk_clear", function(event, rec) {
+                test.lastanimals = null;
+                test.lastanimalsrows = null;
+            });
 
             if (controller.newtest == 1) {
                 this.new_test();

--- a/src/static/js/vaccination.js
+++ b/src/static/js/vaccination.js
@@ -372,7 +372,6 @@ $(function() {
                         $("#animals").animalchoosermulti("set_rows", vaccination.lastanimalsrows);
                         $("#animals").animalchoosermulti("value", vaccination.lastanimals);
                     }
-                    // $("#animals").animalchoosermulti("select");
                     $("#dialog-tableform .asm-textbox, #dialog-tableform .asm-textarea").val("");
                     $("#type").select("value", config.str("AFDefaultVaccinationType"));
                     vaccination.enable_default_cost = true;

--- a/src/static/js/vaccination.js
+++ b/src/static/js/vaccination.js
@@ -502,7 +502,7 @@ $(function() {
 
             $("#animals").on("bulk_clear", function(event, rec) {
                 vaccination.lastanimals = null;
-                vaccination.lastanimalsrows = null;
+                vaccination.lastanimalsrows = null
             });
 
             if (controller.newvacc == 1) {

--- a/src/static/js/vaccination.js
+++ b/src/static/js/vaccination.js
@@ -354,7 +354,6 @@ $(function() {
                 onadd: async function() {
                     vaccination.lastanimals = $("#animals").animalchoosermulti("value");
                     vaccination.lastanimalsrows = $("#animals").animalchoosermulti("get_rows");
-                    console.log(vaccination.lastanimalsrows);
                     try {
                         await tableform.fields_post(dialog.fields, "mode=createbulk", "vaccination");
                         tableform.dialog_close();
@@ -368,7 +367,7 @@ $(function() {
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    if (vaccination.lastanimalsrows != null) {
+                    if (vaccination.lastanimalsrows != null && vaccination.lastanimals != null) {
                         $("#animals").animalchoosermulti("set_rows", vaccination.lastanimalsrows);
                         $("#animals").animalchoosermulti("value", vaccination.lastanimals);
                     }
@@ -500,6 +499,11 @@ $(function() {
             // Same for the vet
             $("#administeringvet").on("change loaded", function(event, rec) { vaccination.lastvet = rec; });
             $("#givenvet").on("change loaded", function(event, rec) { vaccination.lastvet = rec; });
+
+            $("#animals").on("bulk_clear", function(event, rec) {
+                vaccination.lastanimals = null;
+                vaccination.lastanimalsrows = null;
+            });
 
             if (controller.newvacc == 1) {
                 this.new_vacc();

--- a/src/static/js/vaccination.js
+++ b/src/static/js/vaccination.js
@@ -7,6 +7,8 @@ $(function() {
     const vaccination = {
 
         lastanimal: null, 
+        lastanimals: null,
+        lastanimalsrows: null,
         lastvet: null, 
 
         model: function() {
@@ -350,6 +352,9 @@ $(function() {
                     return validate.notblank([ "animals" ]);
                 },
                 onadd: async function() {
+                    vaccination.lastanimals = $("#animals").animalchoosermulti("value");
+                    vaccination.lastanimalsrows = $("#animals").animalchoosermulti("get_rows");
+                    console.log(vaccination.lastanimalsrows);
                     try {
                         await tableform.fields_post(dialog.fields, "mode=createbulk", "vaccination");
                         tableform.dialog_close();
@@ -363,7 +368,11 @@ $(function() {
                 onload: function() {
                     $("#animalrow").hide();
                     $("#animalsrow").show();
-                    $("#animals").animalchoosermulti("clear");
+                    if (vaccination.lastanimalsrows != null) {
+                        $("#animals").animalchoosermulti("set_rows", vaccination.lastanimalsrows);
+                        $("#animals").animalchoosermulti("value", vaccination.lastanimals);
+                    }
+                    // $("#animals").animalchoosermulti("select");
                     $("#dialog-tableform .asm-textbox, #dialog-tableform .asm-textarea").val("");
                     $("#type").select("value", config.str("AFDefaultVaccinationType"));
                     vaccination.enable_default_cost = true;


### PR DESCRIPTION
Following @bobintetley's directions [here](https://github.com/sheltermanager/asm3/issues/1326#issuecomment-4825367806)

In vaccination, medical, and test:

- on bulk form submission, persist IDs and rows in parent elements 
  - IDs are "invisible" but are what gets sent to the backend, rows are required for the animals to be displayed on element reload
- On bulk form reload, if IDs and rows were saved, load them back into the bulk form
- On bulk selection clear, clear the persisted IDs and rows in parent elements