### PR TITLE
querybuilder: Add support for a new type of report, "Person Looking For"

### DIFF
--- a/scripts/schema/schema.py
+++ b/scripts/schema/schema.py
@@ -15,7 +15,7 @@ db = web.database( dbn = "sqlite", db = "scripts/schema/schema.db" )
 VIEWS = [ "adoption", "animal", "animalcontrol", "animalfound", "animallost", 
     "animalmedicalcombined", "animalmedicaltreatment", "animaltest", "animalvaccination", 
     "animalwaitinglist", "owner", "ownercitation", "ownerdonation", 
-    "ownerlicence", "ownertraploan", "ownervoucher" ]
+    "ownerlicence", "ownerlookingfor", "ownertraploan", "ownervoucher" ]
 
 tables = {}
 for table in db.query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"):

--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -96,7 +96,7 @@ TABLES_LOOKUP = ( "accounts", "additionalfield", "animaltype", "basecolour", "br
 VIEWS = ( "v_adoption", "v_animal", "v_animalcontrol", "v_animalfound", "v_animallost", 
     "v_animalmedicalcombined", "v_animalmedicaltreatment", "v_animaltest", "v_animalvaccination", 
     "v_animalwaitinglist", "v_owner", "v_ownercitation", "v_ownerdonation", "v_ownerlicence", 
-    "v_ownertraploan", "v_ownervoucher" )
+    "v_ownerlookingfor", "v_ownertraploan", "v_ownervoucher" )
 
 def sql_structure(dbo: Database) -> str:
     """
@@ -2959,6 +2959,7 @@ def install_db_views(dbo: Database) -> int:
     create_view("v_ownercitation", asm3.financial.get_citation_query(dbo))
     create_view("v_ownerdonation", asm3.financial.get_donation_query(dbo))
     create_view("v_ownerlicence", asm3.financial.get_licence_query(dbo))
+    create_view("v_ownerlookingfor", asm3.person.get_person_lookingfor_query())
     create_view("v_ownertraploan", asm3.animalcontrol.get_traploan_query(dbo))
     create_view("v_ownervoucher", asm3.financial.get_voucher_query(dbo))
     create_view("v_product", asm3.stock.get_product_query(dbo))

--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -2959,7 +2959,7 @@ def install_db_views(dbo: Database) -> int:
     create_view("v_ownercitation", asm3.financial.get_citation_query(dbo))
     create_view("v_ownerdonation", asm3.financial.get_donation_query(dbo))
     create_view("v_ownerlicence", asm3.financial.get_licence_query(dbo))
-    create_view("v_ownerlookingfor", asm3.person.get_person_lookingfor_query())
+    create_view("v_ownerlookingfor", asm3.person.get_person_lookingfor_query(dbo))
     create_view("v_ownertraploan", asm3.animalcontrol.get_traploan_query(dbo))
     create_view("v_ownervoucher", asm3.financial.get_voucher_query(dbo))
     create_view("v_product", asm3.stock.get_product_query(dbo))

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -23,6 +23,20 @@ from datetime import datetime
 ASCENDING = 0
 DESCENDING = 1
 
+def get_person_lookingfor_query() -> str:
+    """
+    Returns the SELECT and JOIN commands necessary for selecting
+    personlookingfor rows with resolved lookups.
+    """
+    return "SELECT o.ID AS PersonID, o.OwnerName, o.OwnerAddress, o.OwnerPostcode, o.OwnerTown, o.OwnerCounty, o.OwnerCountry, o.HomeTelephone, " \
+        "o.OwnerTitle, o.OwnerInitials, o.OwnerForeNames, o.OwnerSurname, o.MobileTelephone, o.WorkTelephone, o.EmailAddress, o.DateOfBirth, o.IdentificationNumber, " \
+        "o.OwnerTitle2, o.OwnerInitials2, o.OwnerForeNames2, o.OwnerSurname2, o.MobileTelephone2, o.WorkTelephone2, o.EmailAddress2, o.DateOfBirth2, o.IdentificationNumber2, " \
+        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup " \
+        "FROM ownerlookingfor olf " \
+        "INNER JOIN owner o ON olf.OwnerID = o.ID " \
+        "INNER JOIN animal a ON olf.AnimalID = a.ID " \
+        "INNER JOIN species s ON a.SpeciesID = s.ID "
+
 def get_person_query(dbo: Database) -> str:
     """
     Returns the SELECT and JOIN commands necessary for selecting

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -23,15 +23,20 @@ from datetime import datetime
 ASCENDING = 0
 DESCENDING = 1
 
-def get_person_lookingfor_query() -> str:
+def get_person_lookingfor_query(dbo: Database) -> str:
     """
     Returns the SELECT and JOIN commands necessary for selecting
     personlookingfor rows with resolved lookups.
     """
+    animalsummary = dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName", "' - '", "a.AgeGroup", "' '", "s.SpeciesName"))
+    personsummary = dbo.sql_concat(("o.OwnerName", "' '", "o.OwnerPostcode"))
     return "SELECT o.ID AS PersonID, o.OwnerName, o.OwnerAddress, o.OwnerPostcode, o.OwnerTown, o.OwnerCounty, o.OwnerCountry, o.HomeTelephone, " \
         "o.OwnerTitle, o.OwnerInitials, o.OwnerForeNames, o.OwnerSurname, o.MobileTelephone, o.WorkTelephone, o.EmailAddress, o.DateOfBirth, o.IdentificationNumber, " \
         "o.OwnerTitle2, o.OwnerInitials2, o.OwnerForeNames2, o.OwnerSurname2, o.MobileTelephone2, o.WorkTelephone2, o.EmailAddress2, o.DateOfBirth2, o.IdentificationNumber2, " \
-        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup " \
+        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup, " \
+        "olf.MatchSummary, " \
+        f"{animalsummary} AS AnimalSummary, " \
+        f"{personsummary} AS PersonSummary " \
         "FROM ownerlookingfor olf " \
         "INNER JOIN owner o ON olf.OwnerID = o.ID " \
         "INNER JOIN animal a ON olf.AnimalID = a.ID " \

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -32,7 +32,7 @@ def get_person_lookingfor_query(dbo: Database) -> str:
         "o.OwnerTitle, o.OwnerInitials, o.OwnerForeNames, o.OwnerSurname, o.MobileTelephone, o.WorkTelephone, o.EmailAddress, o.DateOfBirth, o.IdentificationNumber, " \
         "o.OwnerTitle2, o.OwnerInitials2, o.OwnerForeNames2, o.OwnerSurname2, o.MobileTelephone2, o.WorkTelephone2, o.EmailAddress2, o.DateOfBirth2, o.IdentificationNumber2, " \
         "o.IsAdopter, o.IsBanned, o.IsDonor,o.IsFosterer, o.IDCheck, o.DateLastHomeChecked, o.IsMember, o.IsVolunteer, o.IsDeceased, " \
-        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup, " \
+        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup, a.SpeciesID, " \
         "olf.MatchSummary " \
         "FROM ownerlookingfor olf " \
         "INNER JOIN owner o ON olf.OwnerID = o.ID " \

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -28,15 +28,12 @@ def get_person_lookingfor_query(dbo: Database) -> str:
     Returns the SELECT and JOIN commands necessary for selecting
     personlookingfor rows with resolved lookups.
     """
-    animalsummary = dbo.sql_concat(("a.ShelterCode", "' '", "a.AnimalName", "' - '", "a.AgeGroup", "' '", "s.SpeciesName"))
-    personsummary = dbo.sql_concat(("o.OwnerName", "' '", "o.OwnerPostcode"))
     return "SELECT o.ID AS PersonID, o.OwnerName, o.OwnerAddress, o.OwnerPostcode, o.OwnerTown, o.OwnerCounty, o.OwnerCountry, o.HomeTelephone, " \
         "o.OwnerTitle, o.OwnerInitials, o.OwnerForeNames, o.OwnerSurname, o.MobileTelephone, o.WorkTelephone, o.EmailAddress, o.DateOfBirth, o.IdentificationNumber, " \
         "o.OwnerTitle2, o.OwnerInitials2, o.OwnerForeNames2, o.OwnerSurname2, o.MobileTelephone2, o.WorkTelephone2, o.EmailAddress2, o.DateOfBirth2, o.IdentificationNumber2, " \
+        "o.IsAdopter, o.IsBanned, o.IsDonor,o.IsFosterer, o.IDCheck, o.DateLastHomeChecked, o.IsMember, o.IsVolunteer, o.IsDeceased, " \
         "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup, " \
-        "olf.MatchSummary, " \
-        f"{animalsummary} AS AnimalSummary, " \
-        f"{personsummary} AS PersonSummary " \
+        "olf.MatchSummary " \
         "FROM ownerlookingfor olf " \
         "INNER JOIN owner o ON olf.OwnerID = o.ID " \
         "INNER JOIN animal a ON olf.AnimalID = a.ID " \

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -23,22 +23,6 @@ from datetime import datetime
 ASCENDING = 0
 DESCENDING = 1
 
-def get_person_lookingfor_query(dbo: Database) -> str:
-    """
-    Returns the SELECT and JOIN commands necessary for selecting
-    personlookingfor rows with resolved lookups.
-    """
-    return "SELECT o.ID AS PersonID, o.OwnerName, o.OwnerAddress, o.OwnerPostcode, o.OwnerTown, o.OwnerCounty, o.OwnerCountry, o.HomeTelephone, " \
-        "o.OwnerTitle, o.OwnerInitials, o.OwnerForeNames, o.OwnerSurname, o.MobileTelephone, o.WorkTelephone, o.EmailAddress, o.DateOfBirth, o.IdentificationNumber, " \
-        "o.OwnerTitle2, o.OwnerInitials2, o.OwnerForeNames2, o.OwnerSurname2, o.MobileTelephone2, o.WorkTelephone2, o.EmailAddress2, o.DateOfBirth2, o.IdentificationNumber2, " \
-        "o.IsAdopter, o.IsBanned, o.IsDonor,o.IsFosterer, o.IDCheck, o.DateLastHomeChecked, o.IsMember, o.IsVolunteer, o.IsDeceased, " \
-        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup, a.SpeciesID, " \
-        "olf.MatchSummary " \
-        "FROM ownerlookingfor olf " \
-        "INNER JOIN owner o ON olf.OwnerID = o.ID " \
-        "INNER JOIN animal a ON olf.AnimalID = a.ID " \
-        "INNER JOIN species s ON a.SpeciesID = s.ID "
-
 def get_person_query(dbo: Database) -> str:
     """
     Returns the SELECT and JOIN commands necessary for selecting
@@ -72,6 +56,22 @@ def get_person_query(dbo: Database) -> str:
         "LEFT OUTER JOIN media doc ON doc.LinkID = o.ID AND doc.LinkTypeID = 3 AND doc.DocPhoto = 1 " \
         "LEFT OUTER JOIN site si ON o.SiteID = si.ID " \
         "LEFT OUTER JOIN jurisdiction j ON j.ID = o.JurisdictionID " % ( dbo.sql_today(), dbo.sql_today() )
+
+def get_person_lookingfor_query(dbo: Database) -> str:
+    """
+    Returns the SELECT and JOIN commands necessary for selecting
+    personlookingfor rows with resolved lookups.
+    """
+    return "SELECT o.ID AS PersonID, o.OwnerName, o.OwnerAddress, o.OwnerPostcode, o.OwnerTown, o.OwnerCounty, o.OwnerCountry, o.HomeTelephone, " \
+        "o.OwnerTitle, o.OwnerInitials, o.OwnerForeNames, o.OwnerSurname, o.MobileTelephone, o.WorkTelephone, o.EmailAddress, o.DateOfBirth, o.IdentificationNumber, " \
+        "o.OwnerTitle2, o.OwnerInitials2, o.OwnerForeNames2, o.OwnerSurname2, o.MobileTelephone2, o.WorkTelephone2, o.EmailAddress2, o.DateOfBirth2, o.IdentificationNumber2, " \
+        "o.IsAdopter, o.IsBanned, o.IsDonor,o.IsFosterer, o.IDCheck, o.DateLastHomeChecked, o.IsMember, o.IsVolunteer, o.IsDeceased, " \
+        "a.ID AS AnimalID, a.AnimalName, a.ShelterCode, a.ShortCode, s.SpeciesName, a.BreedName, a.AgeGroup, a.SpeciesID, " \
+        "olf.MatchSummary " \
+        "FROM ownerlookingfor olf " \
+        "INNER JOIN owner o ON olf.OwnerID = o.ID " \
+        "INNER JOIN animal a ON olf.AnimalID = a.ID " \
+        "INNER JOIN species s ON a.SpeciesID = s.ID "
 
 def get_person_export_query(dbo: Database) -> str:
     """ Used by the sql_dump endpoint to export people """

--- a/src/static/js/common.js
+++ b/src/static/js/common.js
@@ -938,6 +938,7 @@ const common = {
     /*Returns a sorted array of column names that are in tablename
       uses the global schema object. */
     get_table_columns(tablename) {
+        console.log(tablename);
         let a = [];
         // Updating codemirror from 5.11 to 5.65 changed the columns from a
         // dictionary to a list, so this is no longer needed.

--- a/src/static/js/reports_querybuilder.js
+++ b/src/static/js/reports_querybuilder.js
@@ -255,6 +255,7 @@ $(function() {
                 '<option value="animalmedicalcombined">' + _("Medical") + '</option>',
                 '<option value="ownerdonation">' + _("Payment") + '</option>',
                 '<option value="owner">' + _("Person") + '</option>',
+                '<option value="ownerlookingfor">' + _("Person Looking For") + '</option>',
                 '<option value="animalwaitinglist">' + _("Waiting List") + '</option>',
                 '</select>',
                 '</td>',

--- a/src/static/js/reports_querybuilder.js
+++ b/src/static/js/reports_querybuilder.js
@@ -219,6 +219,31 @@ $(function() {
             [ _("Volunteer"), "volunteer", "IsVolunteer=1" ]
         ];
 
+        const QB_PERSONLOOKINGFOR_CRITERIA = [
+            [ _("Adopter"), "adopter", "IsAdopter=1" ],
+            [ _("Ask the user for a city"), "askcity", "OwnerTown LIKE '%$ASK STRING {0}$%'"
+                .replace("{0}", _("Enter a city")) ],
+            [ _("Banned"), "banned", "IsBanned=1" ],
+            [ _("Deceased"), "deceased", "IsDeceased=1" ],
+            [ _("Donor"), "donor", "IsDonor=1" ],
+            [ _("Fosterer"), "fosterer", "IsFosterer=1" ],
+            [ _("GiftAid"), "giftaid", "IsGiftAid=1" ],
+            [ _("Homechecked"), "homechecked", "IDCheck=1" ],
+            [ _("Homechecked between two dates"), "homechecktwo", 
+                "DateLastHomeChecked>='$ASK DATE {0}$' AND DateLastHomeChecked<='$ASK DATE {1}$'"
+                .replace("{0}", _("Homechecked between"))
+                .replace("{1}", _("and")) ],
+            [ _("Homechecked by"), "homecheckedby", "IDCheck=1 AND HomeCheckedBy=$ASK PERSON$" ],
+            [ _("Member"), "member", "IsMember=1" ],
+            [ _("No active license held"), "nolicense", "NOT EXISTS(SELECT ID FROM ownerlicence WHERE OwnerID=v_owner.ID " +
+                "AND IssueDate<='$CURRENT_DATE$' AND (ExpiryDate Is Null OR ExpiryDate>'$CURRENT_DATE$'))" ],
+            [ _("Not homechecked"), "nothomechecked", "IDCheck=0" ],
+            [ _("Site matches current user"), "site", "SiteID=$SITE$" ],
+            [ _("Staff"), "staff", "IsStaff=1" ],
+            [ _("Vet"), "vet", "IsVet=1" ],
+            [ _("Volunteer"), "volunteer", "IsVolunteer=1" ]
+        ];
+
         const QB_WAITINGLIST_CRITERIA = [
             [ _("Put on the list between two dates"), "onlisttwodates", 
                 "DatePutOnList >='$ASK DATE {0}$' AND DatePutOnList <= '$ASK DATE {1}$'"
@@ -238,6 +263,7 @@ $(function() {
         qb_medical_criteria: null,
         qb_payment_criteria: null,
         qb_person_criteria: null,
+        qb_personlookingfor_criteria: null,
         qb_waitinglist_criteria: null,
 
         render: function() {
@@ -426,6 +452,7 @@ $(function() {
             reports_querybuilder.qb_medical_criteria = Array.from(QB_MEDICAL_CRITERIA);
             reports_querybuilder.qb_payment_criteria = Array.from(QB_PAYMENT_CRITERIA);
             reports_querybuilder.qb_person_criteria = Array.from(QB_PERSON_CRITERIA);
+            reports_querybuilder.qb_personlookingfor_criteria = Array.from(QB_PERSONLOOKINGFOR_CRITERIA);
             reports_querybuilder.qb_waitinglist_criteria = Array.from(QB_WAITINGLIST_CRITERIA);
             $.each(controller.additionalfields, function(i, v) {
                 if (common.array_in(v.LINKTYPE, ADDITIONAL_ANIMAL)) { 
@@ -750,6 +777,15 @@ $(function() {
                 $("#qbsort").change();
                 $("#qbcriteria").change();
                 reports_querybuilder.qb_active_criteria = reports_querybuilder.qb_payment_criteria;
+            }
+            else if (type == "ownerlookingfor") {
+                $("#qbfields").html(html.list_to_options(common.get_table_columns("v_ownerlookingfor")));
+                $("#qbsort").html(html.list_to_options(common.get_table_columns("v_ownerlookingfor")));
+                $("#qbcriteria").html(html.list_to_options(build_criteria(reports_querybuilder.qb_person_criteria)));
+                $("#qbfields").change();
+                $("#qbsort").change();
+                $("#qbcriteria").change();
+                reports_querybuilder.qb_active_criteria = reports_querybuilder.qb_personlookingfor_criteria;
             }
         },
 

--- a/src/static/js/reports_querybuilder.js
+++ b/src/static/js/reports_querybuilder.js
@@ -220,20 +220,7 @@ $(function() {
         ];
 
         const QB_PERSONLOOKINGFOR_CRITERIA = [
-            [ _("Adopter"), "adopter", "IsAdopter=1" ],
-            [ _("Ask the user for a city"), "askcity", "OwnerTown LIKE '%$ASK STRING {0}$%'"
-                .replace("{0}", _("Enter a city")) ],
-            [ _("Banned"), "banned", "IsBanned=1" ],
-            [ _("Deceased"), "deceased", "IsDeceased=1" ],
-            [ _("Donor"), "donor", "IsDonor=1" ],
-            [ _("Fosterer"), "fosterer", "IsFosterer=1" ],
-            [ _("Homechecked"), "homechecked", "IDCheck=1" ],
-            [ _("Homechecked between two dates"), "homechecktwo", 
-                "DateLastHomeChecked>='$ASK DATE {0}$' AND DateLastHomeChecked<='$ASK DATE {1}$'"
-                .replace("{0}", _("Homechecked between"))
-                .replace("{1}", _("and")) ],
-            [ _("Member"), "member", "IsMember=1" ],
-            [ _("Volunteer"), "volunteer", "IsVolunteer=1" ]
+            [ _("Species"), "species", "SpeciesID='$ASK SPECIES$'"]
         ];
 
         const QB_WAITINGLIST_CRITERIA = [

--- a/src/static/js/reports_querybuilder.js
+++ b/src/static/js/reports_querybuilder.js
@@ -227,20 +227,12 @@ $(function() {
             [ _("Deceased"), "deceased", "IsDeceased=1" ],
             [ _("Donor"), "donor", "IsDonor=1" ],
             [ _("Fosterer"), "fosterer", "IsFosterer=1" ],
-            [ _("GiftAid"), "giftaid", "IsGiftAid=1" ],
             [ _("Homechecked"), "homechecked", "IDCheck=1" ],
             [ _("Homechecked between two dates"), "homechecktwo", 
                 "DateLastHomeChecked>='$ASK DATE {0}$' AND DateLastHomeChecked<='$ASK DATE {1}$'"
                 .replace("{0}", _("Homechecked between"))
                 .replace("{1}", _("and")) ],
-            [ _("Homechecked by"), "homecheckedby", "IDCheck=1 AND HomeCheckedBy=$ASK PERSON$" ],
             [ _("Member"), "member", "IsMember=1" ],
-            [ _("No active license held"), "nolicense", "NOT EXISTS(SELECT ID FROM ownerlicence WHERE OwnerID=v_owner.ID " +
-                "AND IssueDate<='$CURRENT_DATE$' AND (ExpiryDate Is Null OR ExpiryDate>'$CURRENT_DATE$'))" ],
-            [ _("Not homechecked"), "nothomechecked", "IDCheck=0" ],
-            [ _("Site matches current user"), "site", "SiteID=$SITE$" ],
-            [ _("Staff"), "staff", "IsStaff=1" ],
-            [ _("Vet"), "vet", "IsVet=1" ],
             [ _("Volunteer"), "volunteer", "IsVolunteer=1" ]
         ];
 
@@ -781,7 +773,7 @@ $(function() {
             else if (type == "ownerlookingfor") {
                 $("#qbfields").html(html.list_to_options(common.get_table_columns("v_ownerlookingfor")));
                 $("#qbsort").html(html.list_to_options(common.get_table_columns("v_ownerlookingfor")));
-                $("#qbcriteria").html(html.list_to_options(build_criteria(reports_querybuilder.qb_person_criteria)));
+                $("#qbcriteria").html(html.list_to_options(build_criteria(reports_querybuilder.qb_personlookingfor_criteria)));
                 $("#qbfields").change();
                 $("#qbsort").change();
                 $("#qbcriteria").change();


### PR DESCRIPTION
As the title says, add support for a new type of report in the querybuilder "Person Looking For".

I think it will need its own query in person.py/get_person_lookingfor_query() and an appropriate view v_ownerlookingfor that references that query adding to dbupdate.py/VIEWS/install_db_views

The query will start at the ownerlookingfor table and then pull in person and animal columns, mostly the same ones as get_animal_query from animal.py and get_person_query

Needs adding to reports_querybuilder.js after that. In terms of criteria, we probably only need the ability to filter by species to start with.