### PR TITLE
Allow multiple video links in publishing templates

### DIFF
--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -389,6 +389,8 @@ def get_animal_query(dbo: Database) -> str:
         "vid.MediaName AS WebsiteVideoURL, " \
         "vid.MediaMimeType AS WebsiteVideoMimeType, " \
         "vid.MediaNotes AS WebsiteVideoNotes, " \
+        "(SELECT COUNT(*) FROM media mtc WHERE MediaMimeType = 'video/mp4' AND mtc.LinkTypeID = 0 AND mtc.LinkID = a.ID " \
+            "AND ExcludeFromPublish = 0) AS WebsiteVideoCount, " \
         f"CASE WHEN EXISTS(SELECT ID FROM adoption WHERE AnimalID = a.ID AND MovementType = 1 AND MovementDate > {today}) THEN 1 ELSE 0 END AS HasFutureAdoption, " \
         "fo.OwnerName AS FutureOwnerName, " \
         "fo.EmailAddress AS FutureOwnerEmailAddress, " \

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -389,7 +389,8 @@ def get_animal_query(dbo: Database) -> str:
         "vid.MediaName AS WebsiteVideoURL, " \
         "vid.MediaMimeType AS WebsiteVideoMimeType, " \
         "vid.MediaNotes AS WebsiteVideoNotes, " \
-        "(SELECT COUNT(*) FROM media mtc WHERE MediaMimeType = 'video/mp4' AND mtc.LinkTypeID = 0 AND mtc.LinkID = a.ID " \
+        "vid.MediaType, " \
+        f"(SELECT COUNT(*) FROM media mtc WHERE (MediaMimeType = 'video/mp4' OR (MediaMimeType == 'text/url' AND MediaType == {asm3.media.MEDIATYPE_VIDEO_LINK})) AND mtc.LinkTypeID = 0 AND mtc.LinkID = a.ID " \
             "AND ExcludeFromPublish = 0) AS WebsiteVideoCount, " \
         f"CASE WHEN EXISTS(SELECT ID FROM adoption WHERE AnimalID = a.ID AND MovementType = 1 AND MovementDate > {today}) THEN 1 ELSE 0 END AS HasFutureAdoption, " \
         "fo.OwnerName AS FutureOwnerName, " \

--- a/src/asm3/media.py
+++ b/src/asm3/media.py
@@ -85,6 +85,21 @@ def get_media_by_seq(dbo: Database, linktype: int, linkid: int, seq: int) -> Res
     else:
         return None
 
+def get_video_media_by_seq(dbo: Database, linktype: int, linkid: int, seq: int) -> ResultRow:
+    """ Returns video media by a one-based sequence number. 
+        Element 1 is always the preferred.
+        None is returned if the item doesn't exist
+    """
+    rows = dbo.query("SELECT * FROM media " \
+        "WHERE LinkTypeID = ? AND LinkID = ? " \
+        "AND MediaMimeType = 'video/mp4' " \
+        "AND (ExcludeFromPublish = 0 OR ExcludeFromPublish Is Null) " \
+        "ORDER BY WebsiteVideo DESC, Date DESC", (linktype, linkid))
+    if len(rows) >= seq:
+        return rows[seq - 1]
+    else:
+        return None
+
 def get_total_seq(dbo: Database, linktype: int, linkid: int) -> int:
     return dbo.query_int(dbo, "SELECT COUNT(ID) FROM media WHERE LinkTypeID = ? AND LinkID = ? " \
         "AND MediaMimeType = 'image/jpeg' " \
@@ -311,7 +326,8 @@ def get_video_file_data(dbo: Database, mode: str, iid: str = "", seq: int = 0, j
         if seq == 0:
             return mrec( get_web_preferred_video(dbo, ANIMAL, iid) )
         else:
-            return mrec( get_media_by_seq(dbo, ANIMAL, iid, seq) )
+            videodata = get_video_media_by_seq(dbo, ANIMAL, iid, seq)
+            return mrec(videodata)
     elif mode == "person":
         if seq == 0:
             return mrec( get_web_preferred_video(dbo, PERSON, iid) )

--- a/src/asm3/media.py
+++ b/src/asm3/media.py
@@ -97,7 +97,7 @@ def set_video_preferred(dbo: Database, username: str, mid: int) -> None:
     link = dbo.first_row(dbo.query("SELECT LinkID, LinkTypeID FROM media WHERE ID = ?", [mid]))
     dbo.update("media", "LinkID=%d AND LinkTypeID=%d" % (link.LINKID, link.LINKTYPEID), { "WebsiteVideo": 0 })
     dbo.update("media", mid, { "LinkID": link.LINKID, "LinkTypeID": link.LINKTYPEID, 
-        "WebsiteVideo": 1, "Date": dbo.now() }, username) 
+        "WebsiteVideo": 1, "ExcludeFromPublish": 0, "Date": dbo.now() }, username) 
 
 def set_web_preferred(dbo: Database, username: str, mid: int) -> None:
     """
@@ -121,15 +121,19 @@ def set_excluded(dbo: Database, username: str, mid: int, exclude: int = 1) -> No
     """
     Marks the media with id excluded from publishing.
     """
-    link = dbo.first_row(dbo.query("SELECT LinkID, LinkTypeID FROM media WHERE ID = ?", [mid]))
+    link = dbo.first_row(dbo.query("SELECT LinkID, LinkTypeID, MediaMimeType, MediaName, MediaType FROM media WHERE ID = ?", [mid]))
     d = { "LinkID": link.LINKID, "LinkTypeID": link.LINKTYPEID, "ExcludeFromPublish": exclude, "Date": dbo.now() }
     # If we are excluding, we can't be the web or doc or video preferred
     if exclude == 1:
         d["WebsitePhoto"] = 0
         d["DocPhoto"] = 0
-    elif link.LinkTypeID == ANIMAL:
+        d["WebsiteVideo"] = 0
+    elif link.LinkTypeID == ANIMAL and link.MEDIAMIMETYPE == "image/jpeg":
         if 0 == dbo.query_int("SELECT COUNT(ID) FROM media WHERE WebsitePhoto = 1 AND LinkTypeID = ? AND LinkID = ?", [ANIMAL, link.LINKID]):
             d["WebsitePhoto"] = 1
+    elif ( link.LinkTypeID == ANIMAL and link.MEDIAMIMETYPE == "video/mp4" ) or ( link.LinkTypeID == ANIMAL and link.MEDIAMIMETYPE == "text/url" and link.MEDIATYPE == MEDIATYPE_VIDEO_LINK ):
+        if 0 == dbo.query_int("SELECT COUNT(ID) FROM media WHERE WebsiteVideo = 1 AND LinkTypeID = ? AND LinkID = ?", [ANIMAL, link.LINKID]):
+            d["WebsiteVideo"] = 1
     dbo.update("media", mid, d, username)
     if link.LINKTYPEID == ANIMAL:
         asm3.animal.update_animal_status(dbo, link.LINKID, username=username)

--- a/src/asm3/publishers/html.py
+++ b/src/asm3/publishers/html.py
@@ -355,7 +355,7 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
 
     # Add extra tags for websitevideoname2-10 if they exist
     extravideomedia = dbo.query(
-        "SELECT ID, MediaName, MediaType, MediaMimeType FROM media WHERE ExcludeFromPublish = 0 AND (MediaMimeType = 'video/mp4' OR MediaMimeType = 'text/url') AND LinkTypeID = ? AND media.LinkID = ? LIMIT 10",
+        "SELECT ID, MediaName, MediaType, MediaMimeType FROM media WHERE ExcludeFromPublish = 0 AND (MediaMimeType = 'video/mp4' OR MediaMimeType = 'text/url') AND LinkTypeID = ? AND media.LinkID = ? ORDER BY WebsiteVideo desc, Date desc LIMIT 10",
         (asm3.media.ANIMAL, a.ID)
     )
     youtubeattrs = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen'
@@ -374,7 +374,7 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
             else:
                 videourl = f"{SERVICE_URL}?method=animal_video&animalid={a.ID}&seq={videoseqcount}"
             videoseqcount += 1
-            tags[f"WEBSITEVIDEOTAG{extravideocount}"] = f'<video class="asm-video" controls style="background-color: yellow;max-height: none !important;height: auto !important;"><source src="{videourl}" type="video/mp4"></video>'
+            tags[f"WEBSITEVIDEOTAG{extravideocount}"] = f'<video class="asm-video" controls style="max-height: none !important;height: auto !important;"><source src="{videourl}" type="video/mp4"></video>'
         tags[f"WEBSITEVIDEOURL{extravideocount}"] = videourl
 
         # if v[1].WEBSITEVIDEOMIMETYPE == "text/url" and tags[f"WEBSITEVIDEOURL{extravideocount}"].find("watch?") != -1:

--- a/src/asm3/publishers/html.py
+++ b/src/asm3/publishers/html.py
@@ -331,13 +331,16 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
     # Add extra tags for websitemedianame2-10 if they exist
     for x in range(2, 11):
         if a.WEBSITEIMAGECOUNT > x-1: tags[f"WEBMEDIAFILENAME{x}"] = f"{a.WEBSITEMEDIANAME}&seq={x}"
+    
     # Set WebsiteVideoURL if the preferred video is an uploaded file rather than a link
-    if a.WEBSITEVIDEOMIMETYPE == "video/mp4":
+    if a.WEBSITEVIDEOMIMETYPE == "video/mp4":# or (a.WEBSITEVIDEOMIMETYPE == "text/url" and a.MEDIATYPE == asm3.media.MEDIATYPE_VIDEO_LINK):
         if asm3.smcom.active():
             a.WEBSITEVIDEOURL = f"{SERVICE_URL}?account={dbo.name()}&method=animal_video&animalid={a.ID}"
         else:
             a.WEBSITEVIDEOURL = f"{SERVICE_URL}?method=animal_video&animalid={a.ID}"
         tags["WEBSITEVIDEOURL"] = a.WEBSITEVIDEOURL
+
+    
     # If we have a video URL, Add a tag for WEBSITEVIDEOTAG to embed that video in the page
     a.WEBSITEVIDEOTAG = ""
     if a.WEBSITEVIDEOMIMETYPE == "video/mp4":
@@ -351,9 +354,49 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
     tags["WEBSITEVIDEOTAG"] = a.WEBSITEVIDEOTAG
 
     # Add extra tags for websitevideoname2-10 if they exist
-    for x in range(2, 11):
-        if a.WEBSITEVIDEOCOUNT > x-1:
-            tags[f"WEBSITEVIDEOURL{x}"] = f"{a.WEBSITEMEDIANAME}&seq={x}"
+    extravideomedia = dbo.query(
+        "SELECT ID, MediaName, MediaType, MediaMimeType FROM media WHERE ExcludeFromPublish = 0 AND (MediaMimeType = 'video/mp4' OR MediaMimeType = 'text/url') AND LinkTypeID = ? AND media.LinkID = ? LIMIT 10",
+        (asm3.media.ANIMAL, a.ID)
+    )
+    youtubeattrs = 'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen'
+    videoseqcount = 1
+    for v in enumerate(extravideomedia):
+        extravideocount = v[0] + 1
+        tags[f"WEBSITEVIDEOTAG{extravideocount}"] = ""
+        if v[1].MEDIAMIMETYPE == "text/url":
+            videourl = v[1].MEDIANAME
+            if "youtube" in v[1].MediaName:
+                youtubeurl = videourl.replace("watch?v=", "embed/") + "?showinfo=0"
+                tags[f"WEBSITEVIDEOTAG{extravideocount}"] = f'<iframe class="asm-video" src="{youtubeurl}" {youtubeattrs}></iframe>'
+        else:
+            if asm3.smcom.active():
+                videourl = f"{SERVICE_URL}?account={dbo.name()}&method=animal_video&animalid={a.ID}&seq={videoseqcount}"
+            else:
+                videourl = f"{SERVICE_URL}?method=animal_video&animalid={a.ID}&seq={videoseqcount}"
+            videoseqcount += 1
+            tags[f"WEBSITEVIDEOTAG{extravideocount}"] = f'<video class="asm-video" controls style="background-color: yellow;max-height: none !important;height: auto !important;"><source src="{videourl}" type="video/mp4"></video>'
+        tags[f"WEBSITEVIDEOURL{extravideocount}"] = videourl
+
+        # if v[1].WEBSITEVIDEOMIMETYPE == "text/url" and tags[f"WEBSITEVIDEOURL{extravideocount}"].find("watch?") != -1:
+
+    # for x in range(2, 11):
+    #     if a.WEBSITEVIDEOCOUNT > x-1:
+    #         if a.WEBSITEVIDEOMIMETYPE == "text/url":
+    #             videourl = a.MEDIANAME
+    #         elif asm3.smcom.active():
+    #             videourl = f"{SERVICE_URL}?account={dbo.name()}&method=animal_video&animalid={a.ID}&seq={x}"
+    #         else:
+    #             videourl = f"{SERVICE_URL}?method=animal_video&animalid={a.ID}&seq={x}"
+    #         tags[f"WEBSITEVIDEOURL{x}"] = videourl
+
+    #         if a.WEBSITEVIDEOMIMETYPE == "text/url" and tags[f"WEBSITEVIDEOURL{x}"].find("watch?") != -1:
+    #             youtubeurl = f"{a.WEBSITEVIDEOURL}&seq={x}".replace("watch?v=", "embed/") + "?showinfo=0"
+    #             youtubeattrs = 'frameborder="0" ' \
+    #                 'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" ' \
+    #                 'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen'
+    #             tags[f"WEBSITEVIDEOTAG{x}"] = f'<iframe class="asm-video" src="{youtubeurl}" {youtubeattrs}></iframe>'
+    #         else:
+    #             tags[f"WEBSITEVIDEOTAG{x}"] = f'<video class="asm-video" controls><source src=f"{a.WEBSITEVIDEOURL}&seq={x}" type="video/mp4"></video>'
     
     return a
 

--- a/src/asm3/publishers/html.py
+++ b/src/asm3/publishers/html.py
@@ -333,7 +333,7 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
         if a.WEBSITEIMAGECOUNT > x-1: tags[f"WEBMEDIAFILENAME{x}"] = f"{a.WEBSITEMEDIANAME}&seq={x}"
     
     # Set WebsiteVideoURL if the preferred video is an uploaded file rather than a link
-    if a.WEBSITEVIDEOMIMETYPE == "video/mp4":# or (a.WEBSITEVIDEOMIMETYPE == "text/url" and a.MEDIATYPE == asm3.media.MEDIATYPE_VIDEO_LINK):
+    if a.WEBSITEVIDEOMIMETYPE == "video/mp4":
         if asm3.smcom.active():
             a.WEBSITEVIDEOURL = f"{SERVICE_URL}?account={dbo.name()}&method=animal_video&animalid={a.ID}"
         else:
@@ -353,7 +353,7 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
         a.WEBSITEVIDEOTAG = f'<iframe class="asm-video" src="{youtubeurl}" {youtubeattrs}></iframe>'
     tags["WEBSITEVIDEOTAG"] = a.WEBSITEVIDEOTAG
 
-    # Add extra tags for websitevideoname2-10 if they exist
+    # Add extra tags for websitevideoname1-10 if they exist
     extravideomedia = dbo.query(
         "SELECT ID, MediaName, MediaType, MediaMimeType FROM media WHERE ExcludeFromPublish = 0 AND (MediaMimeType = 'video/mp4' OR MediaMimeType = 'text/url') AND LinkTypeID = ? AND media.LinkID = ? ORDER BY WebsiteVideo desc, Date desc LIMIT 10",
         (asm3.media.ANIMAL, a.ID)
@@ -376,27 +376,6 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
             videoseqcount += 1
             tags[f"WEBSITEVIDEOTAG{extravideocount}"] = f'<video class="asm-video" controls style="max-height: none !important;height: auto !important;"><source src="{videourl}" type="video/mp4"></video>'
         tags[f"WEBSITEVIDEOURL{extravideocount}"] = videourl
-
-        # if v[1].WEBSITEVIDEOMIMETYPE == "text/url" and tags[f"WEBSITEVIDEOURL{extravideocount}"].find("watch?") != -1:
-
-    # for x in range(2, 11):
-    #     if a.WEBSITEVIDEOCOUNT > x-1:
-    #         if a.WEBSITEVIDEOMIMETYPE == "text/url":
-    #             videourl = a.MEDIANAME
-    #         elif asm3.smcom.active():
-    #             videourl = f"{SERVICE_URL}?account={dbo.name()}&method=animal_video&animalid={a.ID}&seq={x}"
-    #         else:
-    #             videourl = f"{SERVICE_URL}?method=animal_video&animalid={a.ID}&seq={x}"
-    #         tags[f"WEBSITEVIDEOURL{x}"] = videourl
-
-    #         if a.WEBSITEVIDEOMIMETYPE == "text/url" and tags[f"WEBSITEVIDEOURL{x}"].find("watch?") != -1:
-    #             youtubeurl = f"{a.WEBSITEVIDEOURL}&seq={x}".replace("watch?v=", "embed/") + "?showinfo=0"
-    #             youtubeattrs = 'frameborder="0" ' \
-    #                 'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" ' \
-    #                 'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen'
-    #             tags[f"WEBSITEVIDEOTAG{x}"] = f'<iframe class="asm-video" src="{youtubeurl}" {youtubeattrs}></iframe>'
-    #         else:
-    #             tags[f"WEBSITEVIDEOTAG{x}"] = f'<video class="asm-video" controls><source src=f"{a.WEBSITEVIDEOURL}&seq={x}" type="video/mp4"></video>'
     
     return a
 

--- a/src/asm3/publishers/html.py
+++ b/src/asm3/publishers/html.py
@@ -349,6 +349,12 @@ def embellish_media_urls(dbo: Database, a: ResultRow, tags: Dict[str, str]) -> N
             'referrerpolicy="strict-origin-when-cross-origin" allowfullscreen'
         a.WEBSITEVIDEOTAG = f'<iframe class="asm-video" src="{youtubeurl}" {youtubeattrs}></iframe>'
     tags["WEBSITEVIDEOTAG"] = a.WEBSITEVIDEOTAG
+
+    # Add extra tags for websitevideoname2-10 if they exist
+    for x in range(2, 11):
+        if a.WEBSITEVIDEOCOUNT > x-1:
+            tags[f"WEBSITEVIDEOURL{x}"] = f"{a.WEBSITEMEDIANAME}&seq={x}"
+    
     return a
 
 def get_animal_view_adoptable_html(dbo: Database, style: str = "animalviewadoptable") -> str:

--- a/src/asm3/service.py
+++ b/src/asm3/service.py
@@ -662,7 +662,7 @@ def handler(post: PostedData, path: str, remoteip: str, referer: str, useragent:
         else:
             dummy, data = asm3.media.get_video_file_data(dbo, "animal", asm3.utils.cint(animalid), seq)
             if data == "NOVID": dummy, data = asm3.media.get_image_file_data(dbo, "nopic", 0)
-            return set_cached_response(cache_key, account, "image/jpeg", 86400, 3600, data)
+            return set_cached_response(cache_key, account, "video/mp4", 86400, 3600, data)
 
     elif method =="animal_thumbnail":
         if asm3.utils.cint(animalid) == 0:

--- a/src/media/internet/animalview/body.html
+++ b/src/media/internet/animalview/body.html
@@ -70,6 +70,13 @@
 </div>
 
 $$WEBSITEVIDEOTAG$$
+<span id="morevideosbutton" onclick="showAllVideos()" style="display: none;">more</span>
+<div id="morevideos" style="display: none;">
+$$WEBSITEVIDEOTAG2$$
+$$WEBSITEVIDEOTAG3$$
+$$WEBSITEVIDEOTAG4$$
+$$WEBSITEVIDEOTAG5$$
+</div>
 
 <p>
 <script>
@@ -90,6 +97,10 @@ document.write('<a target="_blank" href="https://twitter.com/share?url=' + u + '
     document.getElementById("additionalanimalcomments").style.display = 'block';
     document.getElementById("morebutton").style.display = 'none';
   }
+  function showAllVideos() {
+    document.getElementById("morevideos").style.display = 'block';
+    document.getElementById("morevideosbutton").style.display = 'none';
+  }
   var rawanimalcomments = document.getElementById("animalcommentsraw").innerHTML.split("<br>");
   var additionalcomments = '';
   var initialanimalcomments = '';
@@ -100,6 +111,16 @@ document.write('<a target="_blank" href="https://twitter.com/share?url=' + u + '
     }
   } else {
     initialanimalcomments = "<p>" + rawanimalcomments[0] + "</p>";
+  }
+
+  let videocount = document.getElementsByClassName("asm-video").length;
+  if (videocount > 1) {
+    let morevideoslabel = (videocount - 1) + " more videos";
+    if (videocount == 2) {
+      morevideoslabel = "1 more video";
+    }
+    document.getElementById("morevideosbutton").innerText = (morevideoslabel) ;
+    document.getElementById("morevideosbutton").style.display = "block";
   }
   
   document.getElementById("animalcomments").innerHTML = initialanimalcomments;

--- a/src/media/internet/animalview/head.html
+++ b/src/media/internet/animalview/head.html
@@ -120,7 +120,7 @@
     	background-color: red;
     }
     
-    #morebutton {
+    #morebutton, #morevideosbutton {
     	cursor: pointer;
         font-weight: bold;
     }

--- a/src/static/js/media.js
+++ b/src/static/js/media.js
@@ -68,7 +68,7 @@ $(function() {
                         });
                         return rv;
                     };
-                    $("#button-video").button("option", "disabled", true); 
+                    $("#button-video").addClass("ui-state-disabled").addClass("ui-button-disabled");
                     $("#button-email").button("option", "disabled", true); 
                     $("#button-emailpdf").button("option", "disabled", true); 
                     $("#button-image").addClass("ui-state-disabled").addClass("ui-button-disabled");
@@ -77,7 +77,7 @@ $(function() {
                     // Only allow the video preferred button to be pressed if the
                     // selection size is one and the selection is a video link
                     if (rows.length == 1 && (rows[0].MEDIATYPE == 2 || rows[0].MEDIAMIMETYPE == "video/mp4")) {
-                        $("#button-video").button("option", "disabled", false);
+                        $("#button-video").removeClass("ui-state-disabled").removeClass("ui-button-disabled");
                     }
                     // Only allow the image buttons to be pressed if the
                     // selection only contains images and the user has the permission to change media
@@ -170,7 +170,7 @@ $(function() {
                 { id: "email", text: _("Email"), icon: "email", enabled: "multi", perm: "emo", tooltip: _("Email a copy of the selected media files") },
                 { id: "emailpdf", text: _("Email PDF"), icon: "pdf", enabled: "multi", perm: "emo", tooltip: _("Email a copy of the selected HTML documents as PDFs") },
                 { id: "image", text: _("Image"), type: "buttonmenu", icon: "image", perm: "cam" },
-                { id: "video", icon: "video", enabled: "one", perm: "cam", tooltip: _("Default video link") },
+                { id: "video", text: _("Video"), type: "buttonmenu", icon: "video", perm: "cam" },
                 { id: "sign", text: _("Sign"), type: "buttonmenu", icon: "signature" },
                 { id: "move", text: _("Move/Copy"), type: "buttonmenu", icon: "copy" },
                 { id: "zip", text: _("Download"), icon: "save", enabled: "multi" },
@@ -296,6 +296,18 @@ $(function() {
                         + ' href="#">' + html.icon("document") + ' ' + _("Make this the default image when creating documents") + '</a></li>',
                     '<li id="button-jpgpdf" class="asm-menu-item"><a '
                         + ' href="#">' + html.icon("pdf") + ' ' + _("Create a PDF of this image") + '</a></li>',
+
+                '</ul>',
+                '</div>',
+
+                '<div id="button-video-body" class="asm-menu-body">',
+                '<ul class="asm-menu-list">',
+                    '<li id="button-include-video" class="asm-menu-item"><a '
+                        + ' href="#">' + html.icon("tick") + ' ' + _("Include this video when publishing") + '</a></li>',
+                    '<li id="button-exclude-video" class="asm-menu-item"><a '
+                        + ' href="#">' + html.icon("cross") + ' ' + _("Exclude this video when publishing") + '</a></li>',
+                    '<li id="button-web-video" class="asm-menu-item"><a '
+                        + ' href="#">' + html.icon("web") + ' ' + _("Make this the default video for the record") + '</a></li>',
 
                 '</ul>',
                 '</div>',
@@ -867,6 +879,7 @@ $(function() {
             // If we aren't including preferred, hide the buttons
             if (!controller.showpreferred) {
                 $("#button-web").hide();
+                $("#button-web-video").hide();
                 $("#button-doc").hide();
                 $("#button-video").hide();
             }
@@ -880,6 +893,8 @@ $(function() {
             if (controller.name != "animal_media") {
                 $("#button-include").hide();
                 $("#button-exclude").hide();
+                $("#button-include-video").hide();
+                $("#button-exclude-video").hide();
             }
 
             $("#button-web").click(function() {
@@ -887,11 +902,16 @@ $(function() {
                 media.ajax(formdata);
             });
 
-            $("#button-video").button().click(function() {
-                $("#button-video").button("disable");
-                let formdata = "mode=video&ids=" + tableform.table_ids(media.table);
+            $("#button-web-video").click(function() {
+                let formdata = "mode=web&ids=" + tableform.table_ids(media.table);
                 media.ajax(formdata);
             });
+
+            // $("#button-video").button().click(function() {
+            //     $("#button-video").button("disable");
+            //     let formdata = "mode=video&ids=" + tableform.table_ids(media.table);
+            //     media.ajax(formdata);
+            // });
 
             $("#button-rotateanti").click(function() {
                 let formdata = "mode=rotateanti&ids=" + tableform.table_ids(media.table);
@@ -923,7 +943,12 @@ $(function() {
                 media.ajax(formdata);
             });
 
-            $("#button-exclude").click(function() {
+            $("#button-include-video").click(function() {
+                let formdata = "mode=include&ids=" + tableform.table_ids(media.table);
+                media.ajax(formdata);
+            });
+
+            $("#button-exclude-video").click(function() {
                 let formdata = "mode=exclude&ids=" + tableform.table_ids(media.table);
                 media.ajax(formdata);
             });
@@ -1011,6 +1036,7 @@ $(function() {
             });
 
             $("#button-image").addClass("ui-state-disabled").addClass("ui-button-disabled");
+            $("#button-video").addClass("ui-state-disabled").addClass("ui-button-disabled");
             $("#button-move").addClass("ui-state-disabled").addClass("ui-button-disabled");
             $("#button-sign").addClass("ui-state-disabled").addClass("ui-button-disabled");
 

--- a/src/static/js/media.js
+++ b/src/static/js/media.js
@@ -145,7 +145,7 @@ $(function() {
                         h.push("<div class=\"centered\">");
                         h.push(media.render_preview_thumbnail(m, true, false, true));
                         h.push("<br/>");
-                        if (m.MEDIAMIMETYPE != "image/jpeg" && m.MEDIAMIMETYPE != "video/mp4") { 
+                        if (m.MEDIAMIMETYPE != "image/jpeg" && m.MEDIAMIMETYPE != "video/mp4" && m.MEDIANOTES) { 
                             h.push("<span>" + html.truncate(m.MEDIANOTES, 30) + "</span><br/>" ); 
                         }
                         h.push(tableform.table_render_edit_link(m.ID, format.date(m.DATE)));
@@ -444,8 +444,20 @@ $(function() {
             if (m.MEDIAMIMETYPE == "image/jpeg" && !m.EXCLUDEFROMPUBLISH && controller.name == "animal_media") {
                 mod_out("tick", _('Include this image when publishing'));
             }
+            if (m.MEDIAMIMETYPE == "video/mp4" && !m.EXCLUDEFROMPUBLISH && controller.name == "animal_media") {
+                mod_out("tick", _('Include this video when publishing'));
+            }
+            if (m.MEDIAMIMETYPE == "text/url" && m.MEDIATYPE == 2 && !m.EXCLUDEFROMPUBLISH && controller.name == "animal_media") {
+                mod_out("tick", _('Include this video when publishing'));
+            }
             if (m.MEDIAMIMETYPE == "image/jpeg" && m.EXCLUDEFROMPUBLISH && controller.name == "animal_media") {
                 mod_out("cross", _('Exclude this image when publishing'));
+            }
+            if (m.MEDIAMIMETYPE == "video/mp4" && m.EXCLUDEFROMPUBLISH && controller.name == "animal_media") {
+                mod_out("cross", _('Exclude this video when publishing'));
+            }
+            if (m.MEDIAMIMETYPE == "text/url" && m.MEDIATYPE == 2 && m.EXCLUDEFROMPUBLISH && controller.name == "animal_media") {
+                mod_out("cross", _('Exclude this video when publishing'));
             }
             if (m.RETAINUNTIL) {
                 let ru = _("Retain until {0}").replace("{0}", format.date(m.RETAINUNTIL));
@@ -903,15 +915,9 @@ $(function() {
             });
 
             $("#button-web-video").click(function() {
-                let formdata = "mode=web&ids=" + tableform.table_ids(media.table);
+                let formdata = "mode=video&ids=" + tableform.table_ids(media.table);
                 media.ajax(formdata);
             });
-
-            // $("#button-video").button().click(function() {
-            //     $("#button-video").button("disable");
-            //     let formdata = "mode=video&ids=" + tableform.table_ids(media.table);
-            //     media.ajax(formdata);
-            // });
 
             $("#button-rotateanti").click(function() {
                 let formdata = "mode=rotateanti&ids=" + tableform.table_ids(media.table);
@@ -945,6 +951,11 @@ $(function() {
 
             $("#button-include-video").click(function() {
                 let formdata = "mode=include&ids=" + tableform.table_ids(media.table);
+                media.ajax(formdata);
+            });
+
+            $("#button-exclude").click(function() {
+                let formdata = "mode=exclude&ids=" + tableform.table_ids(media.table);
                 media.ajax(formdata);
             });
 
@@ -1230,6 +1241,7 @@ $(function() {
 
             // Check if we have pictures but no preferred set and choose one if we don't
             media.check_preferred_images();
+            media.check_preferred_video();
 
             html.media_flag_options(controller.flags, $("#mediaflags"));
             html.media_flag_options(controller.flags, $("#filter"));

--- a/src/static/js/media.js
+++ b/src/static/js/media.js
@@ -666,18 +666,13 @@ $(function() {
             let newweb = false;
             let hasweb = false;
             let webcount = 0;
-            console.log("hasweb " + hasweb + ", newweb " + newweb + ", webcount " + webcount);
             if (!controller.showpreferred) { return false; }
             $.each(controller.media, function(i, v) {
                 if (media.is_video(v) && v.EXCLUDEFROMPUBLISH == 0) {
-                    console.log(v.ID + " is a public video");
                     if (!newweb) { newweb = v.ID; }
                     if (v.WEBSITEVIDEO) { hasweb = true; webcount += 1; }
-                } else {
-                    console.log(v.ID + " is not a public video");
                 }
             });
-            console.log("hasweb " + hasweb + ", newweb " + newweb + ", webcount " + webcount);
             if (!hasweb && newweb) {
                 media.ajax("mode=video&ids=" + newweb);
             }
@@ -762,7 +757,6 @@ $(function() {
         },
 
         is_video: function(s) {
-            console.log(s.MEDIAMIMETYPE);
             return (s.MEDIAMIMETYPE == "video/mp4" || (s.MEDIAMIMETYPE == "text/url" && s.MEDIATYPE == 2));
         },
 

--- a/src/static/js/media.js
+++ b/src/static/js/media.js
@@ -61,6 +61,14 @@ $(function() {
                         });
                         return rv;
                     };
+                    const all_videos = function() {
+                        // Returns true if all rows are videos
+                        let rv = true;
+                        $.each(rows, function(i, v) {
+                            if (v.MEDIAMIMETYPE != "video/mp4" && !(v.MEDIAMIMETYPE == "text/url" && v.MEDIATYPE == 2)) { rv = false; }
+                        });
+                        return rv;
+                    };
                     const no_links = function() {
                         let rv = true;
                         $.each(rows, function(i, v) {
@@ -76,7 +84,7 @@ $(function() {
                     $("#button-sign").addClass("ui-state-disabled").addClass("ui-button-disabled");
                     // Only allow the video preferred button to be pressed if the
                     // selection size is one and the selection is a video link
-                    if (rows.length == 1 && (rows[0].MEDIATYPE == 2 || rows[0].MEDIAMIMETYPE == "video/mp4")) {
+                    if (rows.length > 0 && all_videos() && common.has_permission("cam")) {
                         $("#button-video").removeClass("ui-state-disabled").removeClass("ui-button-disabled");
                     }
                     // Only allow the image buttons to be pressed if the

--- a/src/static/js/media.js
+++ b/src/static/js/media.js
@@ -662,6 +662,33 @@ $(function() {
             }
         },
 
+        check_preferred_videos: function(forcereload) {
+            let newweb = false;
+            let hasweb = false;
+            let webcount = 0;
+            console.log("hasweb " + hasweb + ", newweb " + newweb + ", webcount " + webcount);
+            if (!controller.showpreferred) { return false; }
+            $.each(controller.media, function(i, v) {
+                if (media.is_video(v) && v.EXCLUDEFROMPUBLISH == 0) {
+                    console.log(v.ID + " is a public video");
+                    if (!newweb) { newweb = v.ID; }
+                    if (v.WEBSITEVIDEO) { hasweb = true; webcount += 1; }
+                } else {
+                    console.log(v.ID + " is not a public video");
+                }
+            });
+            console.log("hasweb " + hasweb + ", newweb " + newweb + ", webcount " + webcount);
+            if (!hasweb && newweb) {
+                media.ajax("mode=video&ids=" + newweb);
+            }
+            else if (webcount > 1 && newweb) {
+                media.ajax("mode=video&ids=" + newweb);
+            }
+            else if (forcereload) {
+                common.route_reload();
+            }
+        },
+
         /** Posts the file back to the server. If the option is on and we have the
          *  relevant HTML5 APIs and this is a jpeg image, scales it first */
         post_file: function() {
@@ -732,6 +759,11 @@ $(function() {
 
         is_jpeg: function(s) {
             return media.is_extension(s, "jpg") || media.is_extension(s, "jpeg");
+        },
+
+        is_video: function(s) {
+            console.log(s.MEDIAMIMETYPE);
+            return (s.MEDIAMIMETYPE == "video/mp4" || (s.MEDIAMIMETYPE == "text/url" && s.MEDIATYPE == 2));
         },
 
         /**
@@ -1249,6 +1281,9 @@ $(function() {
 
             // Check if we have pictures but no preferred set and choose one if we don't
             media.check_preferred_images();
+
+            // Check if we have videos but no preferred set and choose one if we don't
+            media.check_preferred_videos();
 
             html.media_flag_options(controller.flags, $("#mediaflags"));
             html.media_flag_options(controller.flags, $("#filter"));

--- a/src/static/js/media.js
+++ b/src/static/js/media.js
@@ -1241,7 +1241,6 @@ $(function() {
 
             // Check if we have pictures but no preferred set and choose one if we don't
             media.check_preferred_images();
-            media.check_preferred_video();
 
             html.media_flag_options(controller.flags, $("#mediaflags"));
             html.media_flag_options(controller.flags, $("#filter"));


### PR DESCRIPTION
Only the preferred/primary video link is returned via the API for adoptable animals. Some customers would like to access more than one video link.