### PR TITLE
PetRescue: New organisation identifiers

### DIFF
--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -1522,8 +1522,20 @@ def petrescue_nsw_rehoming_org_id(dbo: Database) -> str:
 def petrescue_breederid(dbo: Database) -> str:
     return cstring(dbo, "PetRescueBreederID")
 
+def petrescue_nswsupplynumber(dbo: Database) -> str:
+    return cstring(dbo, "NSWSupplyNumber")
+
+def petrescue_qldsupplynumber(dbo: Database) -> str:
+    return cstring(dbo, "QLDSupplyNumber")
+
+def petrescue_sasupplynumber(dbo: Database) -> str:
+    return cstring(dbo, "SASupplyNumber")
+
 def petrescue_vic_sourcenumber(dbo: Database) -> str:
     return cstring(dbo, "PetRescueVICSourceNumber")
+
+def petrescue_vicsupplynumber(dbo: Database) -> str:
+    return cstring(dbo, "VICSupplyNumber")
 
 def petrescue_vic_picnumber(dbo: Database) -> str:
     return cstring(dbo, "PetRescueVICPICNumber")

--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -1501,9 +1501,6 @@ def petrescue_all_desexed(dbo: Database) -> bool:
 def petrescue_all_microchips(dbo: Database) -> bool:
     return cboolean(dbo, "PetRescueAllMicrochips")
 
-def petrescue_sa_daconumber(dbo: Database) -> bool:
-    return cstring(dbo, "PetRescueSADACONumber")
-
 def petrescue_email(dbo: Database) -> str:
     return cstring(dbo, "PetRescueEmail")
 
@@ -1516,12 +1513,6 @@ def petrescue_phone_type(dbo: Database) -> str:
 def petrescue_token(dbo: Database) -> str:
     return cstring(dbo, "PetRescueToken")
 
-def petrescue_nsw_rehoming_org_id(dbo: Database) -> str:
-    return cstring(dbo, "PetRescueNSWRehomingOrgID")
-
-def petrescue_breederid(dbo: Database) -> str:
-    return cstring(dbo, "PetRescueBreederID")
-
 def petrescue_nswsupplynumber(dbo: Database) -> str:
     return cstring(dbo, "NSWSupplyNumber")
 
@@ -1530,9 +1521,6 @@ def petrescue_qldsupplynumber(dbo: Database) -> str:
 
 def petrescue_sasupplynumber(dbo: Database) -> str:
     return cstring(dbo, "SASupplyNumber")
-
-def petrescue_vic_sourcenumber(dbo: Database) -> str:
-    return cstring(dbo, "PetRescueVICSourceNumber")
 
 def petrescue_vicsupplynumber(dbo: Database) -> str:
     return cstring(dbo, "VICSupplyNumber")

--- a/src/asm3/publishers/petrescue.py
+++ b/src/asm3/publishers/petrescue.py
@@ -327,11 +327,7 @@ class PetRescuePublisher(AbstractPublisher):
             "adoption_fee":             asm3.i18n.format_currency_no_symbol(self.locale, an.FEE),
             "species_name":             an.SPECIESNAME,
             "breed_names":              self.get_breed_names(an), # [breed1,breed2] or [breed1]
-            "breeder_id":               breederid, # mandatory for QLD dogs born after 2017-05-26 or South Aus where bred_in_care_of_group==true after 2018-07-01
-            "daco_number":              daconumber, # mandatory for SA cats and dogs
             "pic_number":               vicpicnumber, # mandatory for Victoria livestock (horses etc)
-            "source_number":            vicsourcenumber, # mandatory for Victoria cats and dogs
-            "rehoming_organisation_id": nswrehomingorganisationid, # required for NSW, this OR microchip or breeder_id is mandatory
             "bred_in_care_of_group":    bred_in_care_of_group, 
             "mix":                      self.isCrossBreed(an), # true | false
             "date_of_birth":            asm3.i18n.format_date(an.DATEOFBIRTH, "%Y-%m-%d"), # iso

--- a/src/asm3/publishers/petrescue.py
+++ b/src/asm3/publishers/petrescue.py
@@ -88,6 +88,10 @@ class PetRescuePublisher(AbstractPublisher):
         vicpicnumber = asm3.configuration.petrescue_vic_picnumber(self.dbo)
         phone_type = asm3.configuration.petrescue_phone_type(self.dbo)
         contact_number = asm3.configuration.petrescue_phone_number(self.dbo)
+        nswsupplynumber = asm3.configuration.petrescue_nswsupplynumber(self.dbo)
+        qldsupplynumber = asm3.configuration.petrescue_qldsupplynumber(self.dbo)
+        sasupplynumber = asm3.configuration.petrescue_sasupplynumber(self.dbo)
+        vicsupplynumber = asm3.configuration.petrescue_vicsupplynumber(self.dbo)
         if phone_type == "" or phone_type == "org": contact_number = asm3.configuration.organisation_telephone(self.dbo)
         elif phone_type == "none": contact_number = ""
 
@@ -133,7 +137,8 @@ class PetRescuePublisher(AbstractPublisher):
       
                 data = self.processAnimal(an, all_desexed, adoptable_in, suburb, state, postcode, 
                                           contact_name, contact_number, contact_email, all_microchips, use_coordinator,
-                                          nswrehomingorganisationid, breederid, daconumber, vicpicnumber, vicsourcenumber)
+                                          nswrehomingorganisationid, breederid, daconumber, vicpicnumber, vicsourcenumber,
+                                          nswsupplynumber, qldsupplynumber, sasupplynumber, vicsupplynumber)
 
                 # PetRescue will insert/update accordingly based on whether remote_id/remote_source exists
                 url = PETRESCUE_URL + "listings"
@@ -216,7 +221,8 @@ class PetRescuePublisher(AbstractPublisher):
     def processAnimal(self, an: ResultRow, all_desexed=False, adoptable_in="", 
                       suburb="", state="", postcode="", contact_name="", contact_number="", contact_email="", 
                       all_microchips=False, use_coordinator=0,
-                      nswrehomingorganisationid="", breederid="", daconumber="", vicpicnumber="", vicsourcenumber="") -> Dict:
+                      nswrehomingorganisationid="", breederid="", daconumber="", vicpicnumber="", vicsourcenumber="",
+                      nswsupplynumber="", qldsupplynumber="", sasupplynumber="", vicsupplynumber="") -> Dict:
         """ Processes an animal record and returns a data dictionary to upload as JSON """
         isdog = an.SPECIESID == 1
         iscat = an.SPECIESID == 2
@@ -361,7 +367,11 @@ class PetRescuePublisher(AbstractPublisher):
             "medical_notes":            "", # DISABLED an.HEALTHPROBLEMS, # 4,000 characters medical notes
             "multiple_animals":         an.BONDEDANIMALID > 0 or an.BONDEDANIMAL2ID > 0, # More than one animal included in listing true | false
             "photo_urls":               photourls,
-            "status":                   "active" # active | removed | on_hold | rehomed 
+            "status":                   "active", # active | removed | on_hold | rehomed 
+            "nsw_supply_number":        nswsupplynumber, # Must start with R or B . Must end with exactly 5 digits. Can have up to 14 letters/numbers between the first letter and final 5 digits. Examples: RABCDE12345 , B12345.
+            "vic_supply_number":        vicsupplynumber, # Must be exactly 2 letters followed by exactly 6 digits. Example: RE123456.
+            "qld_supply_number":        qldsupplynumber, # Must start with BIN or BEN , followed by exactly 13 digits. Example: BIN1234567890123.
+            "sa_supply_number":         sasupplynumber # Must start with DACO , followed by at least 1 digit. Example: DACO123456.
         }
 
 

--- a/src/asm3/publishers/petrescue.py
+++ b/src/asm3/publishers/petrescue.py
@@ -81,10 +81,6 @@ class PetRescuePublisher(AbstractPublisher):
         contact_email = asm3.configuration.petrescue_email(self.dbo)
         if contact_email == "": contact_email = asm3.configuration.email(self.dbo)
         use_coordinator = asm3.configuration.petrescue_use_coordinator(self.dbo)
-        breederid = asm3.configuration.petrescue_breederid(self.dbo)
-        daconumber = asm3.configuration.petrescue_sa_daconumber(self.dbo)
-        nswrehomingorganisationid = asm3.configuration.petrescue_nsw_rehoming_org_id(self.dbo)
-        vicsourcenumber = asm3.configuration.petrescue_vic_sourcenumber(self.dbo)
         vicpicnumber = asm3.configuration.petrescue_vic_picnumber(self.dbo)
         phone_type = asm3.configuration.petrescue_phone_type(self.dbo)
         contact_number = asm3.configuration.petrescue_phone_number(self.dbo)
@@ -136,9 +132,8 @@ class PetRescuePublisher(AbstractPublisher):
                     return
       
                 data = self.processAnimal(an, all_desexed, adoptable_in, suburb, state, postcode, 
-                                          contact_name, contact_number, contact_email, all_microchips, use_coordinator,
-                                          nswrehomingorganisationid, breederid, daconumber, vicpicnumber, vicsourcenumber,
-                                          nswsupplynumber, qldsupplynumber, sasupplynumber, vicsupplynumber)
+                    contact_name, contact_number, contact_email, all_microchips, use_coordinator,
+                    vicpicnumber, nswsupplynumber, qldsupplynumber, sasupplynumber, vicsupplynumber)
 
                 # PetRescue will insert/update accordingly based on whether remote_id/remote_source exists
                 url = PETRESCUE_URL + "listings"
@@ -220,8 +215,7 @@ class PetRescuePublisher(AbstractPublisher):
 
     def processAnimal(self, an: ResultRow, all_desexed=False, adoptable_in="", 
                       suburb="", state="", postcode="", contact_name="", contact_number="", contact_email="", 
-                      all_microchips=False, use_coordinator=0,
-                      nswrehomingorganisationid="", breederid="", daconumber="", vicpicnumber="", vicsourcenumber="",
+                      all_microchips=False, use_coordinator=0, vicpicnumber="",
                       nswsupplynumber="", qldsupplynumber="", sasupplynumber="", vicsupplynumber="") -> Dict:
         """ Processes an animal record and returns a data dictionary to upload as JSON """
         isdog = an.SPECIESID == 1

--- a/src/static/js/publish_options.js
+++ b/src/static/js/publish_options.js
@@ -347,18 +347,22 @@ $(function() {
                             { id: "prtoken", post_field: "PetRescueToken", label: 'PetRescue Token', type: "text", doublesize: true }, 
                             { id: "prdesex", post_field: "PetRescueAllDesexed", label: 'Send all animals as desexed', type: "select", options: yesnocfgoptions, 
                                 callout: 'PetRescue will not accept listings for non-desexed animals. Setting this to "Yes" will send all animals as if they are desexed.' }, 
-                            { id: "breederid", post_field: "PetRescueBreederID", label: 'Breeder ID', type: "text", 
-                                callout: 'Your organisation breeder number if applicable. Mandatory for dog listings in QLD. ' + 
-                                'Mandatory for dog listings in South Australia where "bredincareofgroup" is selected.' }, 
-                            { id: "daconumber", post_field: "PetRescueSADACONumber", label: 'DACO Number', type: "text", 
-                                callout: 'Your organisation "Dog and Cat Online" registration number if applicable. ' +
-                                'Mandatory for cat and dog listings in South Australia. ' }, 
-                            { id: "nswrehomingorgid", post_field: "PetRescueNSWRehomingOrgID", label: 'NSW Rehoming Organisation ID', type: "text", 
-                                callout: 'For cats and dogs being rehomed in NSW, a rehoming organisation ID is required OR microchip number OR breeder id' }, 
+                            { id: "nswsupplynumber", post_field: "NSWSupplyNumber", label: 'New South Wales Supply Number', type: "text", callout: 'Must start with R or B . Must end with exactly 5 digits. Can have up to 14 letters/numbers between the first letter and final 5 digits. Examples: RABCDE12345, B12345.' }, 
+                            { id: "vicsupplynumber", post_field: "VICSupplyNumber", label: 'Victoria Supply Number', type: "text", callout: 'Must be exactly 2 letters followed by exactly 6 digits. Example: RE123456.' }, 
+                            { id: "qldsupplynumber", post_field: "QLDSupplyNumber", label: 'Queensland Supply Number', type: "text", callout: 'Must start with BIN or BEN , followed by exactly 13 digits. Example: BIN1234567890123.' }, 
+                            { id: "sasupplynumber", post_field: "SASupplyNumber", label: 'South Australia Number', type: "text", callout: 'Must start with DACO , followed by at least 1 digit. Example: DACO123456.' }, 
+                            // { id: "breederid", post_field: "PetRescueBreederID", label: 'Breeder ID', type: "text", 
+                            //     callout: 'Your organisation breeder number if applicable. Mandatory for dog listings in QLD. ' + 
+                            //     'Mandatory for dog listings in South Australia where "bredincareofgroup" is selected.' }, 
+                            // { id: "daconumber", post_field: "PetRescueSADACONumber", label: 'DACO Number', type: "text", 
+                            //     callout: 'Your organisation "Dog and Cat Online" registration number if applicable. ' +
+                            //     'Mandatory for cat and dog listings in South Australia. ' }, 
+                            // { id: "nswrehomingorgid", post_field: "PetRescueNSWRehomingOrgID", label: 'NSW Rehoming Organisation ID', type: "text", 
+                            //     callout: 'For cats and dogs being rehomed in NSW, a rehoming organisation ID is required OR microchip number OR breeder id' }, 
                             { id: "vicpicnumber", post_field: "PetRescueVICPICNumber", label: 'VIC PIC Number', type: "text", 
                                 callout: 'Property Identification Code for livestock listings in Victoria' }, 
-                            { id: "vicsourcenumber", post_field: "PetRescueVICSourceNumber", label: 'VIC Source Number', type: "text", 
-                                callout: 'Source Number for the Victoria Pet Exchange Register. Mandatory for cat and dog listings in VIC.' }, 
+                            // { id: "vicsourcenumber", post_field: "PetRescueVICSourceNumber", label: 'VIC Source Number', type: "text", 
+                            //     callout: 'Source Number for the Victoria Pet Exchange Register. Mandatory for cat and dog listings in VIC.' }, 
                             { id: "pradoptablein", post_field: "PetRescueAdoptableIn", label: 'Adoptable in states', type: "selectmulti", 
                                 options: '<option value="ACT">Australian Capital Territory</option>' + 
                                 '<option value="NSW">New South Wales</option>' + 


### PR DESCRIPTION
<ul dir="auto"><li><code class="notranslate">nsw_supply_number</code>  : NSW RON/BIN<br></li><li><code class="notranslate">vic_supply_number</code>  : VIC Supply Number / Source Number<br></li><li><code class="notranslate">qld_supply_number</code>  : QLD BIN/BEN<br></li><li><code class="notranslate">sa_supply_number</code>  : SA DACO Organisation Number<br></li></ul><br>These
 new fields are preferred over existing breeder id, source number, daco,
 and rehoming organisation number. The existing fields remain supported 
for backwards compatibility on older listings.<br><br>These fields must be in the expected format. Spaces are stripped before validation.<br>
<markdown-accessiblity-table data-catalyst="">
Field | Validation
-- | --
nsw_supply_number | Must start with R  or B  . Must end with exactly 5 digits. Can have  up to 14 letters/numbers between the first letter and final 5 digits.  Examples: RABCDE12345  , B12345  .
vic_supply_number | Must be exactly 2 letters followed by exactly 6 digits. Example: RE123456  .
qld_supply_number | Must start with BIN or BEN  , followed by exactly 13 digits. Example: BIN1234567890123  .
sa_supply_number | Must start with DACO  , followed by at least 1 digit. Example: DACO123456  .

</markdown-accessiblity-table>
<p dir="auto"><br>Existing integrations do not need to change immediately unless you want to start sending the new state-specific fields.</p>