### PR TITLE
Record alert/warning system

### DIFF
--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3065,25 +3065,24 @@ def get_satellite_counts(dbo: Database, animalid: int) -> Results:
     """
     return dbo.query("SELECT a.ID, " \
         "(SELECT COUNT(*) FROM animalvaccination av WHERE av.AnimalID = a.ID) AS vaccination, " \
-        "(SELECT COUNT(*) FROM animalvaccination av WHERE av.AnimalID = a.ID AND av.DateRequired >= CURRENT_DATE AND av.DateOfVaccination IS NULL) AS vaccinationdue, " \
+        f"(SELECT COUNT(*) FROM animalvaccination av WHERE av.AnimalID = a.ID AND av.DateRequired < {dbo.sql_today()} AND av.DateOfVaccination IS NULL) AS vaccinationdue, " \
         "(SELECT COUNT(*) FROM animalcondition aco WHERE aco.AnimalID = a.ID) AS conditions, " \
         "(SELECT COUNT(*) FROM animaltest at WHERE at.AnimalID = a.ID) AS test, " \
-        "(SELECT COUNT(*) FROM animaltest at WHERE at.AnimalID = a.ID AND at.DateRequired >= CURRENT_DATE AND at.DateOfTest IS NULL) AS testdue, " \
+        f"(SELECT COUNT(*) FROM animaltest at WHERE at.AnimalID = a.ID AND at.DateRequired < {dbo.sql_today()} AND at.DateOfTest IS NULL) AS testdue, " \
         "(SELECT COUNT(*) FROM animalmedical am WHERE am.AnimalID = a.ID) AS medical, " \
-        "(SELECT COUNT(*) FROM animalmedicaltreatment amt WHERE amt.AnimalID = a.ID AND amt.DateRequired >= CURRENT_DATE AND amt.DateGiven IS NULL) AS medicaldue, " \
+        f"(SELECT COUNT(*) FROM animalmedicaltreatment amt WHERE amt.AnimalID = a.ID AND amt.DateRequired < {dbo.sql_today()} AND amt.DateGiven IS NULL) AS medicaldue, " \
         "(SELECT COUNT(*) FROM animalboarding ab WHERE ab.AnimalID = a.ID) AS boarding, " \
         "(SELECT COUNT(*) FROM clinicappointment ca WHERE ca.AnimalID = a.ID) AS clinic, " \
         "(SELECT COUNT(*) FROM animaldiet ad WHERE ad.AnimalID = a.ID) AS diet, " \
         "(SELECT COUNT(*) FROM animaltransport tr WHERE tr.AnimalID = a.ID) AS transport, " \
-        "(SELECT COUNT(*) FROM media me WHERE me.LinkID = a.ID AND me.LinkTypeID = ?) AS media, " \
-        "(SELECT COUNT(*) FROM diary di WHERE di.LinkID = a.ID AND di.LinkType = ?) AS diary, " \
+        f"(SELECT COUNT(*) FROM media me WHERE me.LinkID = a.ID AND me.LinkTypeID = {asm3.media.ANIMAL}) AS media, " \
+        f"(SELECT COUNT(*) FROM diary di WHERE di.LinkID = a.ID AND di.LinkType = {asm3.diary.ANIMAL}) AS diary, " \
         "(SELECT COUNT(*) FROM adoption ad WHERE ad.AnimalID = a.ID) AS movements, " \
-        "(SELECT COUNT(*) FROM log WHERE log.LinkID = a.ID AND log.LinkType = ?) AS logs, " \
+        f"(SELECT COUNT(*) FROM log WHERE log.LinkID = a.ID AND log.LinkType = {asm3.log.ANIMAL}) AS logs, " \
         "(SELECT COUNT(*) FROM ownerdonation od WHERE od.AnimalID = a.ID) AS donations, " \
         "(SELECT COUNT(*) FROM ownerlicence ol WHERE ol.AnimalID = a.ID) AS licence, " \
         "(SELECT COUNT(*) FROM animalcost ac WHERE ac.AnimalID = a.ID) AS costs " \
-        "FROM animal a WHERE a.ID = ?", \
-        (asm3.media.ANIMAL, asm3.diary.ANIMAL, asm3.log.ANIMAL, animalid))
+        "FROM animal a WHERE a.ID = ?", [ animalid ])
 
 def get_random_name(dbo: Database, sex: int = 0) -> str:
     """

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3065,9 +3065,12 @@ def get_satellite_counts(dbo: Database, animalid: int) -> Results:
     """
     return dbo.query("SELECT a.ID, " \
         "(SELECT COUNT(*) FROM animalvaccination av WHERE av.AnimalID = a.ID) AS vaccination, " \
+        "(SELECT COUNT(*) FROM animalvaccination av WHERE av.AnimalID = a.ID AND av.DateRequired >= CURRENT_DATE AND av.DateOfVaccination IS NULL) AS vaccinationdue, " \
         "(SELECT COUNT(*) FROM animalcondition aco WHERE aco.AnimalID = a.ID) AS conditions, " \
         "(SELECT COUNT(*) FROM animaltest at WHERE at.AnimalID = a.ID) AS test, " \
+        "(SELECT COUNT(*) FROM animaltest at WHERE at.AnimalID = a.ID AND at.DateRequired >= CURRENT_DATE AND at.DateOfTest IS NULL) AS testdue, " \
         "(SELECT COUNT(*) FROM animalmedical am WHERE am.AnimalID = a.ID) AS medical, " \
+        "(SELECT COUNT(*) FROM animalmedicaltreatment amt WHERE amt.AnimalID = a.ID AND amt.DateRequired >= CURRENT_DATE AND amt.DateGiven IS NULL) AS medicaldue, " \
         "(SELECT COUNT(*) FROM animalboarding ab WHERE ab.AnimalID = a.ID) AS boarding, " \
         "(SELECT COUNT(*) FROM clinicappointment ca WHERE ca.AnimalID = a.ID) AS clinic, " \
         "(SELECT COUNT(*) FROM animaldiet ad WHERE ad.AnimalID = a.ID) AS diet, " \

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -303,12 +303,15 @@ def get_satellite_counts(dbo: Database, personid: int) -> Results:
         "(SELECT COUNT(*) FROM clinicappointment ca WHERE ca.OwnerID = o.ID) AS clinic, " \
         "(SELECT COUNT(*) FROM log WHERE log.LinkID = o.ID AND log.LinkType = ?) AS logs, " \
         "(SELECT COUNT(*) FROM ownerdonation od WHERE od.OwnerID = o.ID) AS donations, " \
+        "(SELECT COUNT(*) FROM ownerdonation od WHERE od.OwnerID = o.ID AND od.DateDue >= CURRENT_DATE AND od.Date IS NULL) AS donationsdue, " \
         "(SELECT COUNT(*) FROM animalcost ac WHERE ac.OwnerID = o.ID) AS costs, " \
         "(SELECT COUNT(*) FROM ownercitation oc WHERE oc.OwnerID = o.ID) AS citation, " \
+        "(SELECT COUNT(*) FROM ownercitation oc WHERE oc.OwnerID = o.ID AND oc.FineDueDate >= CURRENT_DATE AND oc.FinePaidDate IS NULL) AS citationdue, " \
         "(SELECT COUNT(*) FROM ownerinvestigation oi WHERE oi.OwnerID = o.ID) AS investigation, " \
         "(SELECT COUNT(*) FROM ownerlicence ol WHERE ol.OwnerID = o.ID) AS licence, " \
         "(SELECT COUNT(*) FROM ownerrota r WHERE r.OwnerID = o.ID) AS rota, " \
         "(SELECT COUNT(*) FROM ownertraploan ot WHERE ot.OwnerID = o.ID) AS traploan, " \
+        "(SELECT COUNT(*) FROM ownertraploan ot WHERE ot.OwnerID = o.ID AND ot.ReturnDueDate >= CURRENT_DATE AND ot.ReturnDate IS NULL) AS traploandue, " \
         "(SELECT COUNT(*) FROM ownervoucher ov WHERE ov.OwnerID = o.ID) AS vouchers, " \
         "((SELECT COUNT(*) FROM animal WHERE AdoptionCoordinatorID = o.ID OR BroughtInByOwnerID = o.ID OR OriginalOwnerID = o.ID OR CurrentVetID = o.ID OR OwnersVetID = o.ID OR NeuteredByVetID = o.ID) + " \
         "(SELECT COUNT(*) FROM animal INNER JOIN adoption ON adoption.ID = animal.ActiveMovementID WHERE animal.OwnerID = o.ID AND animal.OwnerID <> adoption.OwnerID) + " \

--- a/src/asm3/person.py
+++ b/src/asm3/person.py
@@ -296,22 +296,22 @@ def get_satellite_counts(dbo: Database, personid: int) -> Results:
     record that a person has.
     """
     return dbo.query("SELECT o.ID, " \
-        "(SELECT COUNT(*) FROM media me WHERE me.LinkID = o.ID AND me.LinkTypeID = ?) AS media, " \
-        "(SELECT COUNT(*) FROM diary di WHERE di.LinkID = o.ID AND di.LinkType = ?) AS diary, " \
+        f"(SELECT COUNT(*) FROM media me WHERE me.LinkID = o.ID AND me.LinkTypeID = {asm3.media.PERSON}) AS media, " \
+        f"(SELECT COUNT(*) FROM diary di WHERE di.LinkID = o.ID AND di.LinkType = {asm3.diary.PERSON}) AS diary, " \
         "(SELECT COUNT(*) FROM adoption ad WHERE ad.OwnerID = o.ID) AS movements, " \
         "(SELECT COUNT(*) FROM animalboarding ab WHERE ab.OwnerID = o.ID) AS boarding, " \
         "(SELECT COUNT(*) FROM clinicappointment ca WHERE ca.OwnerID = o.ID) AS clinic, " \
-        "(SELECT COUNT(*) FROM log WHERE log.LinkID = o.ID AND log.LinkType = ?) AS logs, " \
+        f"(SELECT COUNT(*) FROM log WHERE log.LinkID = o.ID AND log.LinkType = {asm3.log.PERSON}) AS logs, " \
         "(SELECT COUNT(*) FROM ownerdonation od WHERE od.OwnerID = o.ID) AS donations, " \
-        "(SELECT COUNT(*) FROM ownerdonation od WHERE od.OwnerID = o.ID AND od.DateDue >= CURRENT_DATE AND od.Date IS NULL) AS donationsdue, " \
+        f"(SELECT COUNT(*) FROM ownerdonation od WHERE od.OwnerID = o.ID AND od.DateDue < {dbo.sql_today()} AND od.Date IS NULL) AS donationsdue, " \
         "(SELECT COUNT(*) FROM animalcost ac WHERE ac.OwnerID = o.ID) AS costs, " \
         "(SELECT COUNT(*) FROM ownercitation oc WHERE oc.OwnerID = o.ID) AS citation, " \
-        "(SELECT COUNT(*) FROM ownercitation oc WHERE oc.OwnerID = o.ID AND oc.FineDueDate >= CURRENT_DATE AND oc.FinePaidDate IS NULL) AS citationdue, " \
+        f"(SELECT COUNT(*) FROM ownercitation oc WHERE oc.OwnerID = o.ID AND oc.FineDueDate < {dbo.sql_today()} AND oc.FinePaidDate IS NULL) AS citationdue, " \
         "(SELECT COUNT(*) FROM ownerinvestigation oi WHERE oi.OwnerID = o.ID) AS investigation, " \
         "(SELECT COUNT(*) FROM ownerlicence ol WHERE ol.OwnerID = o.ID) AS licence, " \
         "(SELECT COUNT(*) FROM ownerrota r WHERE r.OwnerID = o.ID) AS rota, " \
         "(SELECT COUNT(*) FROM ownertraploan ot WHERE ot.OwnerID = o.ID) AS traploan, " \
-        "(SELECT COUNT(*) FROM ownertraploan ot WHERE ot.OwnerID = o.ID AND ot.ReturnDueDate >= CURRENT_DATE AND ot.ReturnDate IS NULL) AS traploandue, " \
+        f"(SELECT COUNT(*) FROM ownertraploan ot WHERE ot.OwnerID = o.ID AND ot.ReturnDueDate < {dbo.sql_today()} AND ot.ReturnDate IS NULL) AS traploandue, " \
         "(SELECT COUNT(*) FROM ownervoucher ov WHERE ov.OwnerID = o.ID) AS vouchers, " \
         "((SELECT COUNT(*) FROM animal WHERE AdoptionCoordinatorID = o.ID OR BroughtInByOwnerID = o.ID OR OriginalOwnerID = o.ID OR CurrentVetID = o.ID OR OwnersVetID = o.ID OR NeuteredByVetID = o.ID) + " \
         "(SELECT COUNT(*) FROM animal INNER JOIN adoption ON adoption.ID = animal.ActiveMovementID WHERE animal.OwnerID = o.ID AND animal.OwnerID <> adoption.OwnerID) + " \
@@ -324,9 +324,9 @@ def get_satellite_counts(dbo: Database, personid: int) -> Results:
         "(SELECT COUNT(*) FROM animalcontrol WHERE CallerID = o.ID OR VictimID = o.ID " \
         "OR OwnerID = o.ID OR Owner2ID = o.ID or Owner3ID = o.ID) + " \
         "(SELECT COUNT(*) FROM additional af INNER JOIN additionalfield aff ON aff.ID = af.AdditionalFieldID " \
-        "WHERE aff.FieldType = ? AND af.Value = ?) " \
+        f"WHERE aff.FieldType = {asm3.additional.PERSON_LOOKUP} AND af.Value = ?) " \
         ") AS links " \
-        "FROM owner o WHERE o.ID = ?", (asm3.media.PERSON, asm3.diary.PERSON, asm3.log.PERSON, asm3.additional.PERSON_LOOKUP, str(personid), personid))
+        "FROM owner o WHERE o.ID = ?", (str(personid), personid))
 
 def get_reserves_without_homechecks(dbo: Database) -> Results:
     """

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -32,7 +32,11 @@ edit_header = {
         let check_display_icon = function(key, iconname) {
             if (key == "animal") { return html.icon("blank"); }
             if (counts[key.toUpperCase()] > 0) {
-                return html.icon(iconname);
+                let icon = html.icon(iconname);
+                if (counts[key.toUpperCase() + "DUE"]) {
+                    icon += " " + html.icon("warning");
+                }
+                return icon;
             }
             return html.icon("blank");
         };
@@ -583,7 +587,11 @@ edit_header = {
         const check_display_icon = function(key, iconname) {
             if (key == "person") { return html.icon("blank"); }
             if (counts[key.toUpperCase()] > 0) {
-                return html.icon(iconname);
+                let icon = html.icon(iconname);
+                if (counts[key.toUpperCase() + "DUE"]) {
+                    icon += " " + html.icon("warning");
+                }
+                return icon;
             }
             return html.icon("blank");
         };

--- a/src/static/js/header_edit_header.js
+++ b/src/static/js/header_edit_header.js
@@ -29,16 +29,17 @@ edit_header = {
      *           non-zero, an icon is shown on some tabs.
      */
     animal_edit_header: function(a, selected, counts) {
-        let check_display_icon = function(key, iconname) {
+        const check_display_icon = function(key, iconname) {
             if (key == "animal") { return html.icon("blank"); }
             if (counts[key.toUpperCase()] > 0) {
                 let icon = html.icon(iconname);
-                if (counts[key.toUpperCase() + "DUE"]) {
-                    icon += " " + html.icon("warning");
-                }
                 return icon;
             }
             return html.icon("blank");
+        };
+        const check_display_alert = function(key) {
+            if (counts[key.toUpperCase() + "DUE"]) { return '<span class="ui-icon ui-icon-alert"></span>'; }
+            return "";
         };
         let mediaprompt = "";
         if (a.WEBSITEMEDIANAME == null) {
@@ -279,10 +280,10 @@ edit_header = {
             if ((key == "movements") && a.NONSHELTERANIMAL == 1) { return; }
             if ((key == "transport") && config.bool("DisableTransport")) { return; }
             if (key == selected) {
-                s += "<li class=\"ui-tabs-selected ui-state-active\"><a href=\"#\">" + display + " " + check_display_icon(key, iconname) + "</a></li>";
+                s += "<li class=\"ui-tabs-selected ui-state-active\"><a href=\"#\">" + check_display_alert(key) + display + " " + check_display_icon(key, iconname) + "</a></li>";
             }
             else {
-                s += "<li><a href=\"" + url + "?id=" + a.ID + "\">" + display + " " + check_display_icon(key, iconname) + "</a></li>";
+                s += "<li><a href=\"" + url + "?id=" + a.ID + "\">" + check_display_alert(key) + display + " " + check_display_icon(key, iconname) + "</a></li>";
             }
         });
         s += "</ul>";
@@ -588,12 +589,13 @@ edit_header = {
             if (key == "person") { return html.icon("blank"); }
             if (counts[key.toUpperCase()] > 0) {
                 let icon = html.icon(iconname);
-                if (counts[key.toUpperCase() + "DUE"]) {
-                    icon += " " + html.icon("warning");
-                }
                 return icon;
             }
             return html.icon("blank");
+        };
+        const check_display_alert = function(key) {
+            if (counts[key.toUpperCase() + "DUE"]) { return '<span class="ui-icon ui-icon-alert"></span>'; }
+            return "";
         };
         let flags = this.person_flags(p);
         let latestmove = "", latestmovedeceased = "";
@@ -669,10 +671,10 @@ edit_header = {
             if ((key == "movements") && config.bool("DisableMovements")) { return; }
             if ((key == "rota") && ((!p.ISVOLUNTEER && !p.ISSTAFF) || config.bool("DisableRota"))) { return; }
             if (key == selected) {
-                s.push("<li class=\"ui-tabs-selected ui-state-active\"><a href=\"#\">" + display + " " + check_display_icon(key, iconname) + "</a></li>");
+                s.push("<li class=\"ui-tabs-selected ui-state-active\"><a href=\"#\">" + check_display_alert(key) + display + " " + check_display_icon(key, iconname) + "</a></li>");
             }
             else {
-                s.push("<li><a href=\"" + url + "?id=" + p.ID + "\">" + display + " " + check_display_icon(key, iconname) + "</a></li>");
+                s.push("<li><a href=\"" + url + "?id=" + p.ID + "\">" + check_display_alert(key) + display + " " + check_display_icon(key, iconname) + "</a></li>");
             }
         });
         s.push("</ul>");


### PR DESCRIPTION
One customer has said they would like to be able to receive an alert or warning on the animal's record when it has a due vacc, test or medical item. This is a really good idea.

Need to experiment with what looks/works the best. Try the global html.warn function first that puts a box at the top of the screen.

I think the way to do this is to have an exclamation mark type icon shown in the tab.

We could extend animal.get_satellite_counts to include counts of overdue items for each tab as well. Make it a suffix called "due", so for example while we have a count of vacc records as "vaccination", we could also add a count of due vacces call "vaccinationdue".

The code in header_edit_header.js that outputs the tabs can then look for tab + "due" and if it exists and is non-zero, adds the exclamation mark. This could be done in the check_display_icon function at the top of animal_edit_header to make it work for any tab.