### PR TITLE
Method of calculating days on shelter for a date range (DBU 35127)

### DIFF
--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3533,6 +3533,8 @@ def insert_animal_from_form(dbo: Database, post: PostedData, username: str) -> i
     
     update_animallocation(dbo, nextid, username)
 
+    update_animal_figures_onshelter(dbo, nextid, username)
+
     return (nextid, get_code(dbo, nextid))
 
 def update_animal_from_form(dbo: Database, post: PostedData, username: str) -> None:
@@ -3756,6 +3758,8 @@ def update_animal_from_form(dbo: Database, post: PostedData, username: str) -> N
         update_litter_count(dbo, post["litterid"])
     
     update_animallocation(dbo, aid, username)
+
+    update_animal_figures_onshelter(dbo, aid, username)
 
 def update_flags(dbo: Database, username: str, animalid: int, flags: List[str]) -> None:
     """
@@ -7332,15 +7336,15 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str)
     figures = {}
     for osdate in onshelterdates:
         if osdate.month != month or osdate.year != year:
-            figureskey = f"{osdate.month}-{osdate.year}"
+            figureskey = (osdate.month, osdate.year)
             figures[figureskey] = 0
             month = osdate.month
             year = osdate.year
         figures[figureskey] += 1
 
     for f in figures.items():
-        month = int(f[0].split("-")[0])
-        year = int(f[0].split("-")[1])
+        month = int(f[0][0])
+        year = int(f[0][1])
         values = {
             "AnimalID": animalid,
             "MonthMidPoint": datetime(year, month, 15),
@@ -7349,5 +7353,3 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str)
             "DaysOnShelter": f[1]
         }
         dbo.insert("animalfiguresonshelter", values, username, False)
-    
-    return figures

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -7286,6 +7286,14 @@ def create_waitinglist(dbo: Database, username: str, aid: int) -> int:
     }
     return asm3.waitinglist.insert_waitinglist_from_form(dbo, asm3.utils.PostedData(data, l), username)
 
+def update_all_animal_figures_onshelter(dbo: Database, username: str) -> str:
+    animals = dbo.query_list("SELECT ID FROM animal")
+    asm3.asynctask.set_progress_max(dbo, len(animals))
+    for a in enumerate(animals):
+        update_animal_figures_onshelter(dbo, a[1], username)
+        asm3.asynctask.set_progress_value(dbo, a[0])
+    return "OK"
+
 def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str):
     # Delete existing animalfiguresonshelter rows with this animalid
     dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -7289,10 +7289,10 @@ def create_waitinglist(dbo: Database, username: str, aid: int) -> int:
 def update_all_animal_figures_onshelter(dbo: Database, username: str) -> str:
     animals = dbo.query_list("SELECT ID FROM animal")
     asm3.asynctask.set_progress_max(dbo, len(animals))
-    for a in enumerate(animals):
-        update_animal_figures_onshelter(dbo, a[1], username)
-        asm3.asynctask.set_progress_value(dbo, a[0])
-    return "OK"
+    for i, a in enumerate(animals):
+        update_animal_figures_onshelter(dbo, a, username)
+        asm3.asynctask.set_progress_value(dbo, i)
+    return f"OK {len(animals)}"
 
 def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str):
     # Delete existing animalfiguresonshelter rows with this animalid
@@ -7312,12 +7312,27 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str)
             outboundmovements.append(movement.MOVEMENTDATE)
             if movement.RETURNDATE:
                 inboundmovements.append(movement.RETURNDATE)
-    
-    onshelterdates = []
+
     onshelter = True
+    month = 0
+    year = 0
+    figures = {}
+
+    def update_figures():
+        nonlocal month
+        nonlocal year
+        nonlocal date
+        nonlocal figures
+        figureskey = (date.month, date.year)
+        if date.month != month or date.year != year:
+            figures[figureskey] = 0
+            month = date.month
+            year = date.year
+        figures[figureskey] += 1
+    
     while date <= dbo.today():
         if onshelter:
-            onshelterdates.append(date)
+            update_figures()
             if date == deceaseddate:
                 onshelter = False
                 break
@@ -7334,21 +7349,10 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str)
             if inboundmovements:
                 nextinboundmovement = inboundmovements[0]
                 if date == nextinboundmovement:
-                    onshelterdates.append(date)
+                    update_figures()
                     onshelter = True
                     inboundmovements.pop(0)
         date = asm3.i18n.add_days(date, 1)
-    
-    month = 0
-    year = 0
-    figures = {}
-    for osdate in onshelterdates:
-        if osdate.month != month or osdate.year != year:
-            figureskey = (osdate.month, osdate.year)
-            figures[figureskey] = 0
-            month = osdate.month
-            year = osdate.year
-        figures[figureskey] += 1
 
     for f in figures.items():
         month = int(f[0][0])

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -4746,6 +4746,7 @@ def delete_animal(dbo: Database, username: str, animalid: int, ignore_movements:
     for t in [ "adoption", "animalentry", "animalmedical", "animalmedicaltreatment", "animaltest", "animaltransport", "animalvaccination", "clinicappointment" ]:
         dbo.delete(t, "AnimalID=%d" % animalid, username)
     dbo.delete("animal", animalid, username)
+    update_animal_figures_onshelter(dbo, animalid, username)
     # asm3.dbfs.delete_path(dbo, "/animal/%d" % animalid) # Use maint_db_delete_orphaned_media to remove dbfs later if needed
 
 def delete_animals_from_form(dbo: Database, username: str, post: PostedData) -> int:
@@ -7299,7 +7300,10 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str)
     dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)
 
     # Get animals movement history
-    date = get_date_brought_in(dbo, animalid).replace(hour=0, minute=0, second=0, microsecond=0)
+    date = get_date_brought_in(dbo, animalid)
+    if not date:
+        return
+    date = date.replace(hour=0, minute=0, second=0, microsecond=0)
     movements = dbo.query("SELECT MovementDate, ReturnDate, MovementType FROM adoption WHERE AnimalID = ? ORDER BY MovementDate", (animalid,))
 
     # Get deceased date if died on shelter

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -7282,3 +7282,72 @@ def create_waitinglist(dbo: Database, username: str, aid: int) -> int:
     }
     return asm3.waitinglist.insert_waitinglist_from_form(dbo, asm3.utils.PostedData(data, l), username)
 
+def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str):
+    # Delete existing animalfiguresonshelter rows with this animalid
+    dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)
+
+    # Get animals movement history
+    date = get_date_brought_in(dbo, animalid).replace(hour=0, minute=0, second=0, microsecond=0)
+    movements = dbo.query("SELECT MovementDate, ReturnDate, MovementType FROM adoption WHERE AnimalID = ? ORDER BY MovementDate", (animalid,))
+
+    # Get deceased date if died on shelter
+    deceaseddate = dbo.query_date("SELECT DeceasedDate FROM animal WHERE ID = ? AND DiedOffShelter = 0", [animalid])
+
+    outboundmovements = []
+    inboundmovements = []
+    for movement in movements:
+        if asm3.movement.is_exit_movement(dbo, movement.MOVEMENTTYPE):
+            outboundmovements.append(movement.MOVEMENTDATE)
+            if movement.RETURNDATE:
+                inboundmovements.append(movement.RETURNDATE)
+    
+    onshelterdates = []
+    onshelter = True
+    while date <= dbo.today():
+        if onshelter:
+            onshelterdates.append(date)
+            if date == deceaseddate:
+                onshelter = False
+                break
+            nextoutboundmovement = None
+            if outboundmovements:
+                nextoutboundmovement = outboundmovements[0]
+                if date == nextoutboundmovement:
+                    onshelter = False
+                    outboundmovements.pop(0)
+                    if not inboundmovements:
+                        break
+        else:
+            nextinboundmovement = None
+            if inboundmovements:
+                nextinboundmovement = inboundmovements[0]
+                if date == nextinboundmovement:
+                    onshelterdates.append(date)
+                    onshelter = True
+                    inboundmovements.pop(0)
+        date = asm3.i18n.add_days(date, 1)
+    
+    month = 0
+    year = 0
+    figures = {}
+    for osdate in onshelterdates:
+        if osdate.month != month or osdate.year != year:
+            figureskey = f"{osdate.month}-{osdate.year}"
+            figures[figureskey] = 0
+            month = osdate.month
+            year = osdate.year
+        figures[figureskey] += 1
+
+    for f in figures.items():
+        month = int(f[0].split("-")[0])
+        year = int(f[0].split("-")[1])
+        values = {
+            "AnimalID": animalid,
+            "MonthMidPoint": datetime(year, month, 15),
+            "Month": month,
+            "Year": year,
+            "DaysOnShelter": f[1]
+        }
+        dbo.insert("animalfiguresonshelter", values, username, False)
+    
+    return figures

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3533,7 +3533,7 @@ def insert_animal_from_form(dbo: Database, post: PostedData, username: str) -> i
     
     update_animallocation(dbo, nextid, username)
 
-    update_animal_figures_onshelter(dbo, nextid, username)
+    update_animal_figures_onshelter(dbo, nextid)
 
     return (nextid, get_code(dbo, nextid))
 
@@ -3759,7 +3759,7 @@ def update_animal_from_form(dbo: Database, post: PostedData, username: str) -> N
     
     update_animallocation(dbo, aid, username)
 
-    update_animal_figures_onshelter(dbo, aid, username)
+    update_animal_figures_onshelter(dbo, aid)
 
 def update_flags(dbo: Database, username: str, animalid: int, flags: List[str]) -> None:
     """
@@ -4746,7 +4746,7 @@ def delete_animal(dbo: Database, username: str, animalid: int, ignore_movements:
     for t in [ "adoption", "animalentry", "animalmedical", "animalmedicaltreatment", "animaltest", "animaltransport", "animalvaccination", "clinicappointment" ]:
         dbo.delete(t, "AnimalID=%d" % animalid, username)
     dbo.delete("animal", animalid, username)
-    update_animal_figures_onshelter(dbo, animalid, username)
+    update_animal_figures_onshelter(dbo, animalid)
     # asm3.dbfs.delete_path(dbo, "/animal/%d" % animalid) # Use maint_db_delete_orphaned_media to remove dbfs later if needed
 
 def delete_animals_from_form(dbo: Database, username: str, post: PostedData) -> int:
@@ -7287,15 +7287,15 @@ def create_waitinglist(dbo: Database, username: str, aid: int) -> int:
     }
     return asm3.waitinglist.insert_waitinglist_from_form(dbo, asm3.utils.PostedData(data, l), username)
 
-def update_all_animal_figures_onshelter(dbo: Database, username: str) -> str:
+def update_all_animal_figures_onshelter(dbo: Database) -> str:
     animals = dbo.query_list("SELECT ID FROM animal")
     asm3.asynctask.set_progress_max(dbo, len(animals))
     for i, a in enumerate(animals):
-        update_animal_figures_onshelter(dbo, a, username)
+        update_animal_figures_onshelter(dbo, a)
         asm3.asynctask.set_progress_value(dbo, i)
     return f"OK {len(animals)}"
 
-def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str):
+def update_animal_figures_onshelter(dbo: Database, animalid: int):
     # Delete existing animalfiguresonshelter rows with this animalid
     dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)
 
@@ -7368,4 +7368,4 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int, username: str)
             "Year": year,
             "DaysOnShelter": f[1]
         }
-        dbo.insert("animalfiguresonshelter", values, username, False)
+        dbo.insert("animalfiguresonshelter", values, generateID=False, setCreated=False, writeAudit=False)

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -7358,14 +7358,12 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int):
     # Delete existing animalfiguresonshelter rows with this animalid
     dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)
     
+    values = []
     for f in figures.items():
         month = int(f[0][0])
         year = int(f[0][1])
-        values = {
-            "AnimalID": animalid,
-            "MonthMidPoint": datetime(year, month, 15),
-            "Month": month,
-            "Year": year,
-            "DaysOnShelter": f[1]
-        }
-        dbo.insert("animalfiguresonshelter", values, generateID=False, setCreated=False, writeAudit=False)
+        values.append( (animalid, datetime(year, month, 15), month, year, f[1]) )
+    dbo.execute_many(
+        "INSERT INTO animalfiguresonshelter (AnimalID, MonthMidPoint, Month, Year, DaysOnShelter) VALUES (?, ?, ?, ?, ?)",
+        values
+    )

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -7296,9 +7296,6 @@ def update_all_animal_figures_onshelter(dbo: Database) -> str:
     return f"OK {len(animals)}"
 
 def update_animal_figures_onshelter(dbo: Database, animalid: int):
-    # Delete existing animalfiguresonshelter rows with this animalid
-    dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)
-
     # Get animals movement history
     date = get_date_brought_in(dbo, animalid)
     if not date:
@@ -7358,6 +7355,9 @@ def update_animal_figures_onshelter(dbo: Database, animalid: int):
                     inboundmovements.pop(0)
         date = asm3.i18n.add_days(date, 1)
 
+    # Delete existing animalfiguresonshelter rows with this animalid
+    dbo.delete("animalfiguresonshelter", "AnimalID = %s" % animalid)
+    
     for f in figures.items():
         month = int(f[0][0])
         year = int(f[0][1])

--- a/src/asm3/dbupdate.py
+++ b/src/asm3/dbupdate.py
@@ -614,6 +614,14 @@ def sql_structure(dbo: Database) -> str:
     sql += index("animalfiguresannual_EntryReasonID", "animalfiguresannual", "EntryReasonID")
     sql += index("animalfiguresannual_Year", "animalfiguresannual", "Year")
 
+    sql += table("animalfiguresonshelter", (
+        fint("AnimalID"),
+        fdate("MonthMidPoint"),
+        fint("Month"),
+        fint("Year"),
+        fint("DaysOnShelter")), False)
+    sql += index("animalfiguresonshelter_AnimalID", "animalfiguresonshelter", "AnimalID")
+
     sql += table("animalfound", (
         fid(),
         fint("AnimalTypeID"),

--- a/src/asm3/dbupdates/35127.py
+++ b/src/asm3/dbupdates/35127.py
@@ -1,0 +1,12 @@
+from asm3.dbupdate import execute, add_index
+
+fields = ",".join([
+    dbo.ddl_add_table_column("AnimalID", dbo.type_integer, False),
+    dbo.ddl_add_table_column("MonthMidPoint", dbo.type_datetime, False),
+    dbo.ddl_add_table_column("Month", dbo.type_integer, False),
+    dbo.ddl_add_table_column("Year", dbo.type_integer, False),
+    dbo.ddl_add_table_column("DaysOnShelter", dbo.type_integer, False)
+]) + dbo.ddl_audit_table_columns()
+execute(dbo, dbo.ddl_add_table("animalfiguresonshelter", fields) )
+
+add_index(dbo, "animalfiguresonshelter_AnimalID", "animalfiguresonshelter", "AnimalID")

--- a/src/asm3/dbupdates/35127.py
+++ b/src/asm3/dbupdates/35127.py
@@ -6,7 +6,7 @@ fields = ",".join([
     dbo.ddl_add_table_column("Month", dbo.type_integer, False),
     dbo.ddl_add_table_column("Year", dbo.type_integer, False),
     dbo.ddl_add_table_column("DaysOnShelter", dbo.type_integer, False)
-]) + dbo.ddl_audit_table_columns()
+])
 execute(dbo, dbo.ddl_add_table("animalfiguresonshelter", fields) )
 
 add_index(dbo, "animalfiguresonshelter_AnimalID", "animalfiguresonshelter", "AnimalID")

--- a/src/asm3/movement.py
+++ b/src/asm3/movement.py
@@ -506,6 +506,7 @@ def insert_movement_from_form(dbo: Database, username: str, post: PostedData) ->
         update_movement_donation(dbo, movementid)
         asm3.person.update_adopter_flag(dbo, username, post.integer("person"))
         asm3.animal.update_animallocation(dbo, animalid, username)
+        asm3.animal.update_animal_figures_onshelter(dbo, animalid, username)
     return movementid
 
 def update_movement_from_form(dbo: Database, username: str, post: PostedData) -> None:
@@ -554,6 +555,7 @@ def update_movement_from_form(dbo: Database, username: str, post: PostedData) ->
         update_movement_donation(dbo, movementid)
         asm3.person.update_adopter_flag(dbo, username, post.integer("person"))
         asm3.animal.update_animallocation(dbo, post.integer("animal"), username)
+        asm3.animal.update_animal_figures_onshelter(dbo, post.integer("animal"), username)
 
 def delete_movement(dbo: Database, username: str, mid: int) -> None:
     """
@@ -570,6 +572,7 @@ def delete_movement(dbo: Database, username: str, mid: int) -> None:
         asm3.animal.update_variable_animal_data(dbo, m.ANIMALID)
         asm3.person.update_adopter_flag(dbo, username, m.OWNERID)
         asm3.animal.update_animallocation(dbo, m.ANIMALID, username)
+        asm3.animal.update_animal_figures_onshelter(dbo, m.ANIMALID, username)
 
 def cancel_reservation(dbo: Database, username: str, movementid: int) -> None:
     """

--- a/src/asm3/movement.py
+++ b/src/asm3/movement.py
@@ -1159,3 +1159,19 @@ def send_movement_emails(dbo: Database, username: str, post: PostedData) -> bool
         for pid in post.integer_list("personids"):
             asm3.log.add_log_email(dbo, username, asm3.log.PERSON, pid, logtype, emailto, subject, body)
     return rv
+
+def is_exit_movement(dbo: Database, movemementtypeid: int) -> bool:    
+    if movemementtypeid in (0, 9, 10): # None, Reservation, Cancelled Reservation
+        return False
+    if movemementtypeid in (2, 12): # Foster, Permanent Foster
+        if asm3.configuration.foster_on_shelter(dbo):
+            return True
+        else:
+            return False
+    if movemementtypeid == 8: # Retailer
+        if asm3.configuration.retailer_on_shelter(dbo):
+            return True
+        else:
+            return False
+    return True
+    

--- a/src/asm3/movement.py
+++ b/src/asm3/movement.py
@@ -1167,14 +1167,8 @@ def is_exit_movement(dbo: Database, movemementtypeid: int) -> bool:
     if movemementtypeid in (0, 9, 10): # None, Reservation, Cancelled Reservation
         return False
     if movemementtypeid in (2, 12): # Foster, Permanent Foster
-        if asm3.configuration.foster_on_shelter(dbo):
-            return True
-        else:
-            return False
+        return asm3.configuration.foster_on_shelter(dbo)
     if movemementtypeid == 8: # Retailer
-        if asm3.configuration.retailer_on_shelter(dbo):
-            return True
-        else:
-            return False
+        return asm3.configuration.retailer_on_shelter(dbo)
     return True
     

--- a/src/asm3/movement.py
+++ b/src/asm3/movement.py
@@ -506,7 +506,7 @@ def insert_movement_from_form(dbo: Database, username: str, post: PostedData) ->
         update_movement_donation(dbo, movementid)
         asm3.person.update_adopter_flag(dbo, username, post.integer("person"))
         asm3.animal.update_animallocation(dbo, animalid, username)
-        asm3.animal.update_animal_figures_onshelter(dbo, animalid, username)
+        asm3.animal.update_animal_figures_onshelter(dbo, animalid)
     return movementid
 
 def update_movement_from_form(dbo: Database, username: str, post: PostedData) -> None:
@@ -555,7 +555,7 @@ def update_movement_from_form(dbo: Database, username: str, post: PostedData) ->
         update_movement_donation(dbo, movementid)
         asm3.person.update_adopter_flag(dbo, username, post.integer("person"))
         asm3.animal.update_animallocation(dbo, post.integer("animal"), username)
-        asm3.animal.update_animal_figures_onshelter(dbo, post.integer("animal"), username)
+        asm3.animal.update_animal_figures_onshelter(dbo, post.integer("animal"))
 
 def delete_movement(dbo: Database, username: str, mid: int) -> None:
     """
@@ -572,7 +572,7 @@ def delete_movement(dbo: Database, username: str, mid: int) -> None:
         asm3.animal.update_variable_animal_data(dbo, m.ANIMALID)
         asm3.person.update_adopter_flag(dbo, username, m.OWNERID)
         asm3.animal.update_animallocation(dbo, m.ANIMALID, username)
-        asm3.animal.update_animal_figures_onshelter(dbo, m.ANIMALID, username)
+        asm3.animal.update_animal_figures_onshelter(dbo, m.ANIMALID)
 
 def cancel_reservation(dbo: Database, username: str, movementid: int) -> None:
     """

--- a/src/main.py
+++ b/src/main.py
@@ -2647,6 +2647,10 @@ class batch(JSONEndpoint):
 
     def controller(self, o):
         return {}
+    
+    def post_genanos(self, o):
+        l = o.locale
+        asm3.asynctask.function_task(o.dbo, _("Regenerate ALL animal days on shelter", l), asm3.animal.update_all_animal_figures_onshelter, o.dbo, o.user)
 
     def post_genfigyear(self, o):
         l = o.locale

--- a/src/main.py
+++ b/src/main.py
@@ -1925,7 +1925,6 @@ class animal(JSONEndpoint):
         if asm3.configuration.audit_on_view_record(dbo): asm3.audit.view_record(dbo, o.user, "animal", a["ID"], recname)
         asm3.al.debug("opened animal %s" % recname, "main.animal", dbo)
         return {
-            "test": asm3.animal.update_animal_figures_onshelter(dbo, a.ID, o.user),
             "animal": a,
             "activelitters": asm3.animal.get_active_litters_brief(dbo),
             "additional": asm3.additional.get_additional_fields(dbo, a.ID, "animal"),

--- a/src/main.py
+++ b/src/main.py
@@ -1925,6 +1925,7 @@ class animal(JSONEndpoint):
         if asm3.configuration.audit_on_view_record(dbo): asm3.audit.view_record(dbo, o.user, "animal", a["ID"], recname)
         asm3.al.debug("opened animal %s" % recname, "main.animal", dbo)
         return {
+            "test": asm3.animal.update_animal_figures_onshelter(dbo, a.ID, o.user),
             "animal": a,
             "activelitters": asm3.animal.get_active_litters_brief(dbo),
             "additional": asm3.additional.get_additional_fields(dbo, a.ID, "animal"),

--- a/src/main.py
+++ b/src/main.py
@@ -2650,7 +2650,7 @@ class batch(JSONEndpoint):
     
     def post_genanos(self, o):
         l = o.locale
-        asm3.asynctask.function_task(o.dbo, _("Regenerate ALL animal days on shelter", l), asm3.animal.update_all_animal_figures_onshelter, o.dbo, o.user)
+        asm3.asynctask.function_task(o.dbo, _("Regenerate ALL animal days on shelter", l), asm3.animal.update_all_animal_figures_onshelter, o.dbo)
 
     def post_genfigyear(self, o):
         l = o.locale

--- a/src/static/js/batch.js
+++ b/src/static/js/batch.js
@@ -12,6 +12,7 @@ $(function() {
                 '<option value="genallpos">' + _("Recalculate ALL animal locations") + '</option>',
                 '<option value="genallvariable">' + _("Recalculate ALL animal ages/times") + '</option>',
                 '<option value="genallbreeds">' + _("Recalculate ALL animal breed names") + '</option>',
+                '<option value="genanos">' + _("Recalculate ALL animal days on shelter") + '</option>',
                 '<option value="genlitters">' + _("Recalculate active litter counts") + '</option>',
                 '<option value="gendiarylinkinfo">' + _("Regenerate diary link info for incomplete notes") + '</option>',
                 '<option value="genlookingfor">' + _("Regenerate 'Person looking for' report") + '</option>',

--- a/unittest/suite.py
+++ b/unittest/suite.py
@@ -113,7 +113,7 @@ fullsuite = [
 ]
 
 # Running a single suite of tests
-# fullsuite = [ lt(test_service) ]
+# fullsuite = [ lt(test_animal) ]
 
 if __name__ == "__main__":
     emailerrors = False

--- a/unittest/test_animal.py
+++ b/unittest/test_animal.py
@@ -6,6 +6,7 @@ import asm3.utils
 import asm3.lookups
 import asm3.movement
 import asm3.al
+import datetime
 
 class TestAnimal(unittest.TestCase):
    
@@ -454,6 +455,162 @@ class TestAnimal(unittest.TestCase):
     def test_update_all_variable_animal_data(self):
         base.execute("DELETE FROM configuration WHERE ItemName LIKE 'VariableAnimalDataUpdated'")
         asm3.animal.update_all_variable_animal_data(base.get_dbo())
+
+    def test_update_animal_figures_onshelter(self):
+        dbo = base.get_dbo()
+        currentdate = dbo.today()
+        entrydate = datetime.datetime(2025, 1, 1)
+        predicteddos = (currentdate - entrydate).days + 1
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+        
+        # Animal with no movements or death
+        self.assertEqual(predicteddos, reporteddos)
+
+        deceaseddate = datetime.datetime(2026, 1, 1)
+        dbo.update("animal", self.nid, {"DeceasedDate": deceaseddate})
+        asm3.animal.update_animal_figures_onshelter(dbo, self.nid)
+        predicteddos = (deceaseddate - entrydate).days + 1
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+
+        # Animal with deathdate and no movements
+        self.assertEqual(predicteddos, reporteddos)
+
+        dbo.update("animal", self.nid, {"DeceasedDate": None})
+        data = {
+            "animal": str(self.nid),
+            "person": "1",
+            "movementdate": "12/12/2025",
+            "type": "1",
+            "comments": "Created by unit test"
+        }
+        post = asm3.utils.PostedData(data, "en")
+        mid = asm3.movement.insert_movement_from_form(dbo, "test", post)
+        movementdate = datetime.datetime(2025, 12, 12)
+        predicteddos = (movementdate - entrydate).days + 1
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+
+        # Animal with a single adoption movement
+        self.assertEqual(predicteddos, reporteddos)
+
+        movementdate = datetime.datetime(2025, 2, 2)
+        returndate = datetime.datetime(2025, 3, 3)
+        data = {
+            "movementid": str(mid),
+            "animal": str(self.nid),
+            "person": "1",
+            "movementdate": "02/02/2025",
+            "type": "1",
+            "returndate": "03/03/2025",
+            "comments": "Created by unit test"
+        }
+        post = asm3.utils.PostedData(data, "en")
+        asm3.movement.update_movement_from_form(dbo, "test", post)
+        preadoptiondays = (movementdate - entrydate).days + 1
+        postadoptiondays = (currentdate - returndate).days + 1
+        predicteddos = preadoptiondays + postadoptiondays
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+
+        # Animal with a single adoption movement with a return date
+        self.assertEqual(predicteddos, reporteddos)
+
+        data = {
+            "animal": str(self.nid),
+            "adoptionno": "utm2",
+            "person": "1",
+            "movementdate": "04/04/2025",
+            "type": "1",
+            "comments": "Created by unit test"
+        }
+        post = asm3.utils.PostedData(data, "en")
+        mid2 = asm3.movement.insert_movement_from_form(dbo, "test", post)
+        movement2date = datetime.datetime(2025, 4, 4)
+        preadoptiondays = (movementdate - entrydate).days + 1
+        postadoptiondays = (movement2date - returndate).days + 1
+        predicteddos = preadoptiondays + postadoptiondays
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+
+        # Animal with an adoption with a return and second adoption with no return date
+        self.assertEqual(predicteddos, reporteddos)
+
+        return2date = datetime.datetime(2025, 6, 6)
+        data = {
+            "movementid": str(mid2),
+            "animal": str(self.nid),
+            "adoptionno": "utm2",
+            "person": "1",
+            "movementdate": "04/04/2025",
+            "type": "1",
+            "returndate": "06/06/2025",
+            "comments": "Created by unit test"
+        }
+        post = asm3.utils.PostedData(data, "en")
+        asm3.movement.update_movement_from_form(dbo, "test", post)
+        preadoptiondays = (movementdate - entrydate).days + 1
+        betweenadoptiondays = (movement2date - returndate).days + 1
+        postadoption2days = (currentdate - return2date).days + 1
+        predicteddos = preadoptiondays + betweenadoptiondays + postadoption2days
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+
+        # Animal with two returned adoptions
+        self.assertEqual(predicteddos, reporteddos)
+
+        deceaseddate = datetime.datetime(2025, 7, 7)
+        dbo.update("animal", self.nid, {"DeceasedDate": deceaseddate})
+        asm3.animal.update_animal_figures_onshelter(dbo, self.nid)
+        preadoptiondays = (movementdate - entrydate).days + 1
+        betweenadoptiondays = (movement2date - returndate).days + 1
+        postadoption2days = (deceaseddate - return2date).days + 1
+        predicteddos = preadoptiondays + betweenadoptiondays + postadoption2days
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+
+        # Animal with two returned adoptions followed by death
+        self.assertEqual(predicteddos, reporteddos)
+
+        data = {
+            "movementid": str(mid2),
+            "animal": str(self.nid),
+            "adoptionno": "utm2",
+            "person": "1",
+            "movementdate": "04/04/2025",
+            "type": "1",
+            "returndate": "",
+            "comments": "Created by unit test"
+        }
+        post = asm3.utils.PostedData(data, "en")
+        asm3.movement.update_movement_from_form(dbo, "test", post)
+        dbo.update("animal", self.nid, {"DeceasedDate": deceaseddate, "DiedOffShelter": "1"})
+        preadoptiondays = (movementdate - entrydate).days + 1
+        betweenadoptiondays = (movement2date - returndate).days + 1
+        predicteddos = preadoptiondays + betweenadoptiondays
+        reporteddos = dbo.query_int(
+            "SELECT SUM(DaysOnShelter) FROM animalfiguresonshelter WHERE AnimalID = ?",
+            (self.nid,)
+        )
+    
+        # Animal with returned adoptions followed by second non returned adoption with death while off shelter
+        self.assertEqual(predicteddos, reporteddos)
+
 
     def test_update_foster_variable_animal_data(self):
         asm3.animal.update_foster_variable_animal_data(base.get_dbo())


### PR DESCRIPTION
This is something that comes up fairly often. Some shelters want to be able to calculate how many days an animal was on shelter for a given period. I'm sure the RSPCA SAWA report wanted to do something like this as well.

I gave up on the making an SQL token or using code to generate this on the fly. I think the best way is a clever data structure:

Create a new table, animalfiguresonshelter with these columns animalid, monthmidpoint, month, year, daysonshelter. index on animalid

This table should be calculated by a function in animal.py called update_animal_figures_onshelter(animalid). The function first deletes any previous rows for animalid, then regenerates them from the animal's data and movements. Every month that the animal has ever been on shelter will be given a day count. Figuring out which months the animal was on shelter will be the tricky bit. The monthmidpoint field will contain a date of half way through that month. This will make it easy to filter this table with a date range for reports.

This function will be called from insert_animal_from_form, update_animal_from_form as well as movement.insert/update/delete_movement

There should be a new option under batch.js/trigger batch processes that allows you to call this function for all animals (which will take a while in some databases).