### PR TITLE
Include Events in Full Calendar View

### DIFF
--- a/src/static/js/calendarview.js
+++ b/src/static/js/calendarview.js
@@ -118,7 +118,7 @@ $(function() {
 
             // If there's an ev parameter, sync our checkboxes
             let ev = common.querystring_param("ev");
-            if (!ev) { ev = "dvmtbcrolp"; }
+            if (!ev) { ev = "dvmtbcrolpe"; }
             $("#toggles input").each(function() {
                 if (ev.indexOf( $(this).attr("data") ) != -1) {
                     $(this).prop("checked", true);


### PR DESCRIPTION
When calendar view is chosen from the quick links all checkboxes are ticked except events. Include the events.