### PR TITLE
AdoptAPet: New columns

### DIFF
--- a/doc/manual/publishing.rst
+++ b/doc/manual/publishing.rst
@@ -292,6 +292,19 @@ This means you can then grab it from their FTP server and edit it yourself if
 you wish to change any mappings, then put it back again. This is generally only
 necessary for users who want to send colour information.
 
+Extra fields
+^^^^^^^^^^^^
+
+AdoptAPet.com have a number of extra fields that you can set by creating additional
+animal fields with certain names in your database. The system responds to the
+field names, you can label them anything you want, they must be linked to
+animal records.
+
+* indooronly (Yes/No): Must the pet be denied access to outdoors?
+
+* specialdietaryneeds (Yes/No): Does the pet require a special diet?
+
+
 maddiesfund.org / Maddie's Pet Assistant
 ----------------------------------------
 

--- a/src/asm3/publishers/adoptapet.py
+++ b/src/asm3/publishers/adoptapet.py
@@ -214,7 +214,14 @@ class AdoptAPetPublisher(FTPPublisher):
             "#22:Birthdate=Birthdate\n" \
             "#23:Sizecurrent=Sizecurrent\n" \
             "#24:SizeUOM=SizeUOM\n" \
-            "#25:AdoptionFee=AdoptionFee"
+            "#25:AdoptionFee=AdoptionFee\n" \
+            "#26:Cratetrained=Cratetrained\n" \
+            "#27:HeartwormNegative=HeartwormNegative\n" \
+            "#28:HeartwormPositive=HeartwormPositive\n" \
+            "#29:Leashtrained=Leashtrained\n" \
+            "#30:IndoorOnly=IndoorOnly\n" \
+            "#31:FIVPositive=FIVPositive\n" \
+            "#32:SpecialDietaryNeeds=SpecialDietaryNeeds"
         else:
             defmap += "#10:Color=Color\n" \
             "#11:Description=Description\n" \
@@ -232,7 +239,14 @@ class AdoptAPetPublisher(FTPPublisher):
             "#23:Birthdate=Birthdate\n" \
             "#24:Sizecurrent=Sizecurrent\n" \
             "#25:SizeUOM=SizeUOM\n" \
-            "#26:AdoptionFee=AdoptionFee"
+            "#26:AdoptionFee=AdoptionFee\n" \
+            "#27:Cratetrained=Cratetrained\n" \
+            "#28:HeartwormNegative=HeartwormNegative\n" \
+            "#29:HeartwormPositive=HeartwormPositive\n" \
+            "#30:Leashtrained=Leashtrained\n" \
+            "#31:IndoorOnly=IndoorOnly\n" \
+            "#32:FIVPositive=FIVPositive\n" \
+            "#33:SpecialDietaryNeeds=SpecialDietaryNeeds"
 
         return defmap
 
@@ -288,7 +302,7 @@ class AdoptAPetPublisher(FTPPublisher):
         # NOTE: We still publish even if there are no animals. This prevents situations
         # where the last animal can't be removed from AdoptAPet because the shelter
         # has no animals to send.
-        animals = self.getMatchingAnimals()
+        animals = self.getMatchingAnimals(includeAdditionalFields=True)
         if len(animals) == 0:
             self.log("No animals found to publish, sending empty file.")
 
@@ -439,6 +453,35 @@ class AdoptAPetPublisher(FTPPublisher):
             line.append("")
         else:
             line.append(str(int(asm3.utils.cint(an.FEE) / 100)))
+        # Cratetrained
+        line.append(self.apYesNoUnknown(an.ISCRATETRAINED))
+        heartwormnegative = ""
+        heartwormpositive = ""
+        if an.HEARTWORMTESTRESULT == 1:
+            heartwormnegative = "1"
+            heartwormpositive = "0"
+        elif an.HEARTWORMTESTRESULT == 2:
+            heartwormnegative = "0"
+            heartwormpositive = "1"
+        # HeartwormNegative
+        line.append(heartwormnegative)
+        # HeartwormPositive
+        line.append(heartwormpositive)
+        # Leashtrained
+        line.append(self.apYesNoUnknown(an.ISGOODONLEAD))
+        # IndoorOnly
+        if "INDOORONLY" in an:
+            line.append(self.apYesNoUnknown(an.INDOORONLY))
+        else:
+            line.append("")
+        # FIVPositive
+        line.append(self.apYesNoUnknown(an.COMBITESTRESULT))
+        # SpecialDietaryNeeds
+        if "SPECIALDIETARYNEEDS" in an:
+            line.append(self.apYesNoUnknown(an.SPECIALDIETARYNEEDS))
+        else:
+            line.append("")
+
         return self.csvLine(line)
     
     def removeAllImages(self) -> str:


### PR DESCRIPTION
AdoptAPet are now supporting additional columns, Add these columns to the end of the map as 25/26+ and populate them (see function apMapFile).

The columns are:

Cratetrained
HeartwormNegative
HeartwormPositive
Leashtrained
IndoorOnly
FIVPositive
SpecialDietaryNeeds

We could infer special dietary needs from diet records possibly. I can't remember if we have something for indoor only.

The column values for all of these is 0 for negative, 1 for positive or blank/empty string for unknown.