### PR TITLE
Person Choooser returns empty string

### DIFF
--- a/src/static/js/common_personchooser.js
+++ b/src/static/js/common_personchooser.js
@@ -488,7 +488,8 @@ $.fn.personchooser = asm_widget({
                 // Hide retired options from the lookups
                 dialogadd.find(".asm-selectbox").select("removeRetiredOptions", "all");
                 // Was there a value already set by the markup? If so, use it
-                if (t.val() != "" && t.val() != "0") {
+                if (t.val() == "") {t.val("0");}
+                if (t.val() != "0") {
                     self.loadbyid.call(self, t, t.val());
                 }
             },

--- a/src/static/js/common_personchooser.js
+++ b/src/static/js/common_personchooser.js
@@ -487,8 +487,9 @@ $.fn.personchooser = asm_widget({
                 }
                 // Hide retired options from the lookups
                 dialogadd.find(".asm-selectbox").select("removeRetiredOptions", "all");
+                // Is value blank? If so change to zero
+                if (t.val() == "")  { t.val("0"); }
                 // Was there a value already set by the markup? If so, use it
-                if (t.val() == "") {t.val("0");}
                 if (t.val() != "0") {
                     self.loadbyid.call(self, t, t.val());
                 }


### PR DESCRIPTION
There are places (animal original owner, receive payment) where a person chooser with no person selected returns an empty string rather than a zero.