### PR TITLE
Move Product - Required quantity field not enforced

### DIFF
--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1124,7 +1124,7 @@ const tableform = {
      *        label: "label", // if label contains <label markup, overrides generation and uses supplied value instead
      *        labelpos: "before|after|above", (only valid for textarea (before|above) and check (before|after))
      *        labelclasses: "exraclass", extra classes to apply to the label
-     *        type: "check|text|textarea|richtextarea|date|time|currency|number|intnumber|animal|person|raw|nextcol", 
+     *        type: "check|text|textarea|richtextarea|date|time|currency|number|intnumber|select|animal|person|raw|nextcol", 
      *        rowid: "thisrow", (id for the row containing the label/field)
      *        readonly: false, (shown in dialog_show_add, hidden in dialog_show_edit)
      *        halfsize: false, (use the asm-halftextbox class)

--- a/src/static/js/common_tableform.js
+++ b/src/static/js/common_tableform.js
@@ -1124,7 +1124,7 @@ const tableform = {
      *        label: "label", // if label contains <label markup, overrides generation and uses supplied value instead
      *        labelpos: "before|after|above", (only valid for textarea (before|above) and check (before|after))
      *        labelclasses: "exraclass", extra classes to apply to the label
-     *        type: "check|text|textarea|richtextarea|date|time|currency|number|select|animal|person|raw|nextcol", 
+     *        type: "check|text|textarea|richtextarea|date|time|currency|number|intnumber|animal|person|raw|nextcol", 
      *        rowid: "thisrow", (id for the row containing the label/field)
      *        readonly: false, (shown in dialog_show_add, hidden in dialog_show_edit)
      *        halfsize: false, (use the asm-halftextbox class)

--- a/src/static/js/product.js
+++ b/src/static/js/product.js
@@ -180,7 +180,10 @@ $(function() {
                     click: function() {
                         product.move_product_init();
                         tableform.show_okcancel_dialog("#dialog-moveproduct", _("Move"), { 
-                            width: 500, okclick: product.move_product, notblank: [ "movementfrom", "movementto" ] });
+                            width: 500, okclick: product.move_product, 
+                            notblank: [ "movementquantity", "movementfrom", "movementto" ],
+                            notzero: [ "movementquantity", ]
+                         });
                     }
                 },
                 { id: "showusage", text: _("Usage"), icon: "stock-usage", enabled: "one", perm: "asl", 
@@ -222,7 +225,7 @@ $(function() {
                 html.info(_("Adjust stock levels of this product in bulk.")),
                 tableform.fields_render([
                 { type: "raw", markup: '<span class="strong" id="moveproductname"></span>' },
-                { post_field: "movementquantity", json_field: "MOVEMENTQUANTITY", label: _("Quantity"), type: "intnumber", xmarkup: ' &times; ', rowclose: false, halfsize: true, validation: "notzero" },
+                { post_field: "movementquantity", json_field: "MOVEMENTQUANTITY", label: _("Quantity"), type: "intnumber", xmarkup: ' &times; ', rowclose: false, halfsize: true },
                 { post_field: "movementunit", json_field: "MOVEMENTUNIT", type: "select", justwidget: true, halfsize: true },
                 { type: "rowclose" },
                 { post_field: "movementdate", json_field: "MOVEMENTDATE", label: _("Date"), type: "date" },


### PR DESCRIPTION
The quantity field has the red asterisk but it allows users to submit the dialog content with this field blank or zero. No usage record is created when this is done.