### PR TITLE
Lost and Found - Fill in area/postcode from person record

### DIFF
--- a/src/static/js/lostfound_new.js
+++ b/src/static/js/lostfound_new.js
@@ -168,12 +168,12 @@ $(function() {
             
             // Auto fill area and postcode if not set
             $("#owner").on("change", async function(event, rec) {
-                let $areainput = $("#arealost");
+                let areainput = $("#arealost");
                 if ( lostfound_new.mode == "found" ) {
-                    $areainput = $("#areafound");
+                    areainput = $("#areafound");
                 }
-                if ( !$areainput.val() && !$("#areapostcode").val() ) {
-                    $areainput.val(rec.OWNERADDRESS);
+                if ( !areainput.val() && !$("#areapostcode").val() ) {
+                    areainput.val(rec.OWNERADDRESS);
                     $("#areapostcode").val(rec.OWNERPOSTCODE);
                 }
             });

--- a/src/static/js/lostfound_new.js
+++ b/src/static/js/lostfound_new.js
@@ -165,6 +165,18 @@ $(function() {
                 lostfound_new.update_breed_select();
                 additional.toggle_elements_by_species("additional", $("#species").val());
             });
+            
+            // Auto fill area and postcode if not set
+            $("#owner").on("change", async function(event, rec) {
+                let $areainput = $("#arealost");
+                if ( lostfound_new.mode == "found" ) {
+                    $areainput = $("#areafound");
+                }
+                if ( !$areainput.val() && !$("#areapostcode").val() ) {
+                    $areainput.val(rec.OWNERADDRESS);
+                    $("#areapostcode").val(rec.OWNERPOSTCODE);
+                }
+            });
         },
 
         sync: function() {


### PR DESCRIPTION
If a person is selected and the arealost/areafound and areapostcode fields are blank, they are filled using the address and postcode from the person record.