### PR TITLE
Add caller, suspect and victim address and phone numbers to incident emails

### DIFF
--- a/src/asm3/animalcontrol.py
+++ b/src/asm3/animalcontrol.py
@@ -25,6 +25,10 @@ def get_animalcontrol_query(dbo: Database) -> str:
         "o1.OwnerName AS OwnerName, o1.OwnerName AS OwnerName1, o2.OwnerName AS OwnerName2, o3.OwnerName AS OwnerName3, " \
         "o1.OwnerName AS SuspectName, o1.OwnerAddress AS SuspectAddress, o1.OwnerTown AS SuspectTown, o1.OwnerCounty AS SuspectCounty, o1.OwnerPostcode AS SuspectPostcode, " \
         "o1.HomeTelephone AS SuspectHomeTelephone, o1.WorkTelephone AS SuspectWorkTelephone, o1.MobileTelephone AS SuspectMobileTelephone, " \
+        "o2.OwnerName AS Suspect2Name, o2.OwnerAddress AS Suspect2Address, o2.OwnerTown AS Suspect2Town, o2.OwnerCounty AS Suspect2County, o2.OwnerPostcode AS Suspect2Postcode, " \
+        "o2.HomeTelephone AS Suspect2HomeTelephone, o2.WorkTelephone AS Suspect2WorkTelephone, o2.MobileTelephone AS Suspect2MobileTelephone, " \
+        "o3.OwnerName AS Suspect3Name, o3.OwnerAddress AS Suspect3Address, o3.OwnerTown AS Suspect3Town, o3.OwnerCounty AS Suspect3County, o3.OwnerPostcode AS Suspect3Postcode, " \
+        "o3.HomeTelephone AS Suspect3HomeTelephone, o3.WorkTelephone AS Suspect3WorkTelephone, o3.MobileTelephone AS Suspect3MobileTelephone, " \
         "vo.OwnerName AS VictimName, vo.OwnerAddress AS VictimAddress, vo.OwnerTown AS VictimTown, vo.OwnerCounty AS VictimCounty, vo.OwnerPostcode AS VictimPostcode," \
         "vo.HomeTelephone AS VictimHomeTelephone, vo.WorkTelephone AS VictimWorkTelephone, vo.MobileTelephone AS VictimMobileTelephone, " \
         "ti.IncidentName, ci.CompletedName, pl.LocationName, j.JurisdictionName, " \

--- a/src/asm3/animalcontrol.py
+++ b/src/asm3/animalcontrol.py
@@ -25,10 +25,6 @@ def get_animalcontrol_query(dbo: Database) -> str:
         "o1.OwnerName AS OwnerName, o1.OwnerName AS OwnerName1, o2.OwnerName AS OwnerName2, o3.OwnerName AS OwnerName3, " \
         "o1.OwnerName AS SuspectName, o1.OwnerAddress AS SuspectAddress, o1.OwnerTown AS SuspectTown, o1.OwnerCounty AS SuspectCounty, o1.OwnerPostcode AS SuspectPostcode, " \
         "o1.HomeTelephone AS SuspectHomeTelephone, o1.WorkTelephone AS SuspectWorkTelephone, o1.MobileTelephone AS SuspectMobileTelephone, " \
-        "o2.OwnerName AS Suspect2Name, o2.OwnerAddress AS Suspect2Address, o2.OwnerTown AS Suspect2Town, o2.OwnerCounty AS Suspect2County, o2.OwnerPostcode AS Suspect2Postcode, " \
-        "o2.HomeTelephone AS Suspect2HomeTelephone, o2.WorkTelephone AS Suspect2WorkTelephone, o2.MobileTelephone AS Suspect2MobileTelephone, " \
-        "o3.OwnerName AS Suspect3Name, o3.OwnerAddress AS Suspect3Address, o3.OwnerTown AS Suspect3Town, o3.OwnerCounty AS Suspect3County, o3.OwnerPostcode AS Suspect3Postcode, " \
-        "o3.HomeTelephone AS Suspect3HomeTelephone, o3.WorkTelephone AS Suspect3WorkTelephone, o3.MobileTelephone AS Suspect3MobileTelephone, " \
         "vo.OwnerName AS VictimName, vo.OwnerAddress AS VictimAddress, vo.OwnerTown AS VictimTown, vo.OwnerCounty AS VictimCounty, vo.OwnerPostcode AS VictimPostcode," \
         "vo.HomeTelephone AS VictimHomeTelephone, vo.WorkTelephone AS VictimWorkTelephone, vo.MobileTelephone AS VictimMobileTelephone, " \
         "ti.IncidentName, ci.CompletedName, pl.LocationName, j.JurisdictionName, " \

--- a/src/static/js/common.js
+++ b/src/static/js/common.js
@@ -333,6 +333,10 @@ const common = {
         return v instanceof String || typeof(v) == "string";
     },
 
+    join_not_falsy: function(array, delimiter="<br />") {
+        return array.filter(v => v).join(delimiter);
+    },
+
     browser_is: {
         android: navigator.userAgent.match(/Android/i) != null,
         ios:     navigator.userAgent.match(/iPod|iPad|iPhone/i) != null,

--- a/src/static/js/incident.js
+++ b/src/static/js/incident.js
@@ -303,14 +303,33 @@ $(function() {
                     }
                 });
                 let i = controller.incident;
-                let msg = [ 
-                    _("Type") + ": " + i.INCIDENTNAME,
-                    _("Date/Time") + ": " + format.date(i.INCIDENTDATETIME) + " " + format.time(i.INCIDENTDATETIME),
-                    _("Address") + ": " + i.DISPATCHADDRESS + ' ' + i.DISPATCHTOWN + ' ' + i.DISPATCHCOUNTY + ' ' + i.DISPATCHPOSTCODE,
-                    _("Notes") + ": " + common.nulltostr(i.CALLNOTES),
-                    _("Caller") + ": " + common.nulltostr(i.CALLERNAME),
-                    _("Victim") + ": " + common.nulltostr(i.VICTIMNAME),
-                    _("Suspect") + ": " + common.nulltostr(i.OWNERNAME1)
+
+                let formatcontact = function(data) {
+                    let output = "";
+                    $.each(data, function(i, v) {
+                        if (v) {
+                            output += v + "<br />";
+                        }
+                    });
+                    return output.trim();
+                }
+                let dispatchaddress = formatcontact([i.DISPATCHADDRESS, i.DISPATCHTOWN, i.DISPATCHCOUNTY, i.DISPATCHPOSTCODE]);
+                let callerdetails = formatcontact([i.CALLERNAME, common.replace_all(i.CALLERADDRESS, "\n", "<br />"), i.CALLERTOWN, i.CALLERCOUNTY, i.CALLERPOSTCODE, i.CALLERMOBILETELEPHONE, i.CALLERHOMETELEPHONE, i.CALLERWORKTELEPHONE]);
+                let victimdetails = formatcontact([i.VICTIMNAME, common.replace_all(i.VICTIMADDRESS, "\n", "<br />"), i.VICTIMTOWN, i.VICTIMCOUNTY, i.VICTIMPOSTCODE, i.VICTIMMOBILETELEPHONE, i.VICTIMHOMETELEPHONE, i.VICTIMWORKTELEPHONE]);
+                let suspectdetails = formatcontact([i.SUSPECTNAME, common.replace_all(i.SUSPECTADDRESS, "\n", "<br />"), i.SUSPECTTOWN, i.SUSPECTCOUNTY, i.SUSPECTPOSTCODE, i.SUSPECTMOBILETELEPHONE, i.SUSPECTHOMETELEPHONE, i.SUSPECTWORKTELEPHONE]);
+                let msg = [
+                    '<div style="padding: 10px;">',
+                        '<h1>' + format.padleft(controller.incident.ACID, 6) + '</h1>',
+                        '<table border="0" cellpadding="10" style="border-collapse: collapse;width: 100%;">',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Type") + '</td><td style="vertical-align: top;">' + i.INCIDENTNAME + '</td></tr>',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Date/Time") + '</td><td style="vertical-align: top;">' + format.date(i.INCIDENTDATETIME) + " " + format.time(i.INCIDENTDATETIME) + '</td></tr>',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Address") + '</td><td style="vertical-align: top;">' + dispatchaddress + '</td></tr>',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Notes") + '</td><td style="vertical-align: top;">' + common.nulltostr(i.CALLNOTES) + '</td></tr>',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Caller") + '</td><td style="vertical-align: top;">' + callerdetails + '</td></tr>',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Victim") + '</td><td style="vertical-align: top;">' + victimdetails + '</td></tr>',
+                            '<tr style="border-bottom: 1px solid black;border-top: 1px solid black;"><td style="vertical-align: top;">' + _("Suspect") + '</td><td style="vertical-align: top;">' + suspectdetails + '</td></tr>',
+                        '</table>',
+                    '</div>'
                 ].join("\n");
                 let subject = html.decode(_("Dispatch {0}: {1}")
                         .replace("{0}", format.padleft(controller.incident.ACID, 6))
@@ -323,7 +342,7 @@ $(function() {
                     name: common.iif(emailaddress.indexOf(",") == -1, emailname, ""),
                     email: emailaddress,
                     logtypes: controller.logtypes,
-                    message: "<p>" + common.replace_all(html.decode(msg), "\n", "<br/>") + "</p>",
+                    message: msg,
                     subject: subject,
                     templates: controller.templatesemail
                 });

--- a/src/static/js/incident.js
+++ b/src/static/js/incident.js
@@ -303,20 +303,10 @@ $(function() {
                     }
                 });
                 let i = controller.incident;
-
-                let formatcontact = function(data) {
-                    let output = "";
-                    $.each(data, function(i, v) {
-                        if (v) {
-                            output += v + "<br />";
-                        }
-                    });
-                    return output.trim();
-                }
-                let dispatchaddress = formatcontact([i.DISPATCHADDRESS, i.DISPATCHTOWN, i.DISPATCHCOUNTY, i.DISPATCHPOSTCODE]);
-                let callerdetails = formatcontact([i.CALLERNAME, common.replace_all(i.CALLERADDRESS, "\n", "<br />"), i.CALLERTOWN, i.CALLERCOUNTY, i.CALLERPOSTCODE, i.CALLERMOBILETELEPHONE, i.CALLERHOMETELEPHONE, i.CALLERWORKTELEPHONE]);
-                let victimdetails = formatcontact([i.VICTIMNAME, common.replace_all(i.VICTIMADDRESS, "\n", "<br />"), i.VICTIMTOWN, i.VICTIMCOUNTY, i.VICTIMPOSTCODE, i.VICTIMMOBILETELEPHONE, i.VICTIMHOMETELEPHONE, i.VICTIMWORKTELEPHONE]);
-                let suspectdetails = formatcontact([i.SUSPECTNAME, common.replace_all(i.SUSPECTADDRESS, "\n", "<br />"), i.SUSPECTTOWN, i.SUSPECTCOUNTY, i.SUSPECTPOSTCODE, i.SUSPECTMOBILETELEPHONE, i.SUSPECTHOMETELEPHONE, i.SUSPECTWORKTELEPHONE]);
+                let dispatchaddress = common.join_not_falsy([i.DISPATCHADDRESS, i.DISPATCHTOWN, i.DISPATCHCOUNTY, i.DISPATCHPOSTCODE]);
+                let callerdetails = common.join_not_falsy([i.CALLERNAME, common.replace_all(i.CALLERADDRESS, "\n", "<br />"), i.CALLERTOWN, i.CALLERCOUNTY, i.CALLERPOSTCODE, i.CALLERMOBILETELEPHONE, i.CALLERHOMETELEPHONE, i.CALLERWORKTELEPHONE]);
+                let victimdetails = common.join_not_falsy([i.VICTIMNAME, common.replace_all(i.VICTIMADDRESS, "\n", "<br />"), i.VICTIMTOWN, i.VICTIMCOUNTY, i.VICTIMPOSTCODE, i.VICTIMMOBILETELEPHONE, i.VICTIMHOMETELEPHONE, i.VICTIMWORKTELEPHONE]);
+                let suspectdetails = common.join_not_falsy([i.SUSPECTNAME, common.replace_all(i.SUSPECTADDRESS, "\n", "<br />"), i.SUSPECTTOWN, i.SUSPECTCOUNTY, i.SUSPECTPOSTCODE, i.SUSPECTMOBILETELEPHONE, i.SUSPECTHOMETELEPHONE, i.SUSPECTWORKTELEPHONE]);
                 let msg = [
                     '<div style="padding: 10px;">',
                         '<h1>' + format.padleft(controller.incident.ACID, 6) + '</h1>',


### PR DESCRIPTION
As title, incident emails only currently include the names of callers, victims and suspects. It has been requested we add the addresses and phone number information for these people as well.