### PR TITLE
Add batch jobs to retroactively translate stored lookup strings.

### DIFF
--- a/src/asm3/lookups.py
+++ b/src/asm3/lookups.py
@@ -1,9 +1,10 @@
 
+import asm3.al
 import asm3.cachedisk
 import asm3.configuration
 import asm3.financial
 import asm3.utils
-from asm3.i18n import _
+from asm3.i18n import _, real_locale
 from asm3.sitedefs import URL_MICROCHIP_PREFIXES
 from asm3.typehints import datetime, Database, Dict, List, LocationFilter, Results, Tuple
 
@@ -93,6 +94,19 @@ LOOKUP_DESCFIELD = 3
 LOOKUP_MODIFIERS = 4
 LOOKUP_FOREIGNKEYS = 5
 LOOKUP_DEFAULTCONFIG = 6
+
+# Extra translatable lookup columns not covered by LOOKUP_TABLES name fields.
+# Add tables/columns here as needed. Primary key is always ID.
+TRANSLATABLE_LOOKUP_COLUMNS = {
+    "lksdiarylink":     ("LinkType",),
+    "lksdonationfreq":  ("Frequency",),
+    "lksfieldlink":     ("LinkType",),
+    "lksfieldtype":     ("FieldType",),
+    "lksloglink":       ("LinkType",),
+    "lksmedialink":     ("LinkType",),
+    "lksmediatype":     ("MediaType",),
+    "lksunittype":      ("UnitName",)
+}
 
 COLOURSCHEMES = [
     { "ID": 1, "FGCOL": "", "BGCOL": "" },
@@ -1239,6 +1253,47 @@ def update_lookup(dbo: Database, username: str, iid: int, lookup: str, name: str
 def update_lookup_retired(dbo: Database, username: str, lookup: str, iid: int, retired: int) -> None:
     """ Updates lookup item with ID=iid, setting IsRetired=retired """
     dbo.update(lookup, iid, { "IsRetired": retired }, username, setLastChanged=False)
+
+def _lookup_translation_map() -> Dict[str, Tuple[str, ...]]:
+    """ Name fields from LOOKUP_TABLES plus any extra columns in TRANSLATABLE_LOOKUP_COLUMNS. """
+    mapping = {}
+    for table, spec in LOOKUP_TABLES.items():
+        mapping[table] = (spec[LOOKUP_NAMEFIELD],)
+    for table, cols in TRANSLATABLE_LOOKUP_COLUMNS.items():
+        mapping[table] = tuple(dict.fromkeys(mapping.get(table, ()) + cols))
+    return mapping
+
+def translate_stored_lookup_strings(dbo: Database, lks_only: bool) -> str:
+    """
+    Re-applies translations to stored lookup values that were inserted in English
+    because no translation existed at insert time.
+    lks_only: True for static lks* tables, False for all other mapped lookup tables.
+    """
+    l = dbo.locale
+    if real_locale(l) == "en":
+        asm3.al.info("skipping lookup translation for English locale", "lookups.translate_stored_lookup_strings", dbo)
+        return "OK 0"
+    updated = 0
+    for table, columns in _lookup_translation_map().items():
+        if lks_only != table.startswith("lks"):
+            continue
+        rows = dbo.query("SELECT ID, %s FROM %s" % (", ".join(columns), table))
+        for row in rows:
+            values = {}
+            for col in columns:
+                s = row[col.upper()]
+                if not s:
+                    continue
+                translated = _(s, l)
+                if s != translated:
+                    values[col] = translated
+                    asm3.al.info("%s.%s ID=%s '%s' -> '%s'" % (table, col, row.ID, s, translated),
+                        "lookups.translate_stored_lookup_strings", dbo)
+            if values:
+                dbo.update(table, row.ID, values, setLastChanged=False, setRecordVersion=False, writeAudit=False)
+                updated += len(values)
+    asm3.al.info("translated %d lookup values" % updated, "lookups.translate_stored_lookup_strings", dbo)
+    return "OK %d" % updated
 
 def delete_lookup(dbo: Database, username: str, lookup: str, iid: int) -> None:
     l = dbo.locale

--- a/src/main.py
+++ b/src/main.py
@@ -2715,6 +2715,14 @@ class batch(JSONEndpoint):
         l = o.locale
         asm3.asynctask.function_task(o.dbo, _("Send the weekly fosterer email now", l), asm3.automail.fosterer_weekly, o.dbo, o.user, True)
 
+    def post_translks(self, o):
+        l = o.locale
+        asm3.asynctask.function_task(o.dbo, _("Apply translations to static lookup values", l), asm3.lookups.translate_stored_lookup_strings, o.dbo, True)
+
+    def post_translookups(self, o):
+        l = o.locale
+        asm3.asynctask.function_task(o.dbo, _("Apply translations to lookup values", l), asm3.lookups.translate_stored_lookup_strings, o.dbo, False)
+
 class boarding(JSONEndpoint):
     url = "boarding"
     js_module = "boarding"

--- a/src/static/js/batch.js
+++ b/src/static/js/batch.js
@@ -23,7 +23,9 @@ $(function() {
                 '<option value="genfigyear">' + _("Regenerate annual animal figures for") + '</option>',
                 '<option value="genfigmonth">' + _("Regenerate monthly animal figures for") + '</option>',
                 '<option value="resetnnncodes">' + _("Reset NNN animal code counts for this year") + '</option>',
-                '<option value="sendfostererweekly">' + _("Send the weekly fosterer email now") + '</option>'
+                '<option value="sendfostererweekly">' + _("Send the weekly fosterer email now") + '</option>',
+                '<option value="translks">' + _("Apply translations to static lookup values") + '</option>',
+                '<option value="translookups">' + _("Apply translations to lookup values") + '</option>'
             ].join("\n");
         },
 

--- a/unittest/test_lookups.py
+++ b/unittest/test_lookups.py
@@ -62,3 +62,55 @@ class TestLookups(unittest.TestCase):
         asm3.lookups.get_animal_flags(base.get_dbo())
         asm3.lookups.get_person_flags(base.get_dbo())
 
+    def _snapshot_lookup_strings(self, dbo, lks_only):
+        snap = []
+        for table, columns in asm3.lookups._lookup_translation_map().items():
+            if lks_only != table.startswith("lks"):
+                continue
+            for row in dbo.query("SELECT ID, %s FROM %s" % (", ".join(columns), table)):
+                snap.append((table, row.ID, { c: row[c.upper()] for c in columns }))
+        return snap
+
+    def _restore_lookup_strings(self, dbo, snap):
+        for table, iid, values in snap:
+            dbo.update(table, iid, values, setLastChanged=False, setRecordVersion=False, writeAudit=False)
+
+    def test_translate_stored_lookup_strings_english_noop(self):
+        dbo = base.get_dbo()
+        orig_locale = dbo.locale
+        dbo.locale = "en"
+        try:
+            self.assertEqual("OK 0", asm3.lookups.translate_stored_lookup_strings(dbo, True))
+            self.assertEqual("OK 0", asm3.lookups.translate_stored_lookup_strings(dbo, False))
+        finally:
+            dbo.locale = orig_locale
+
+    def test_translate_stored_lks_strings(self):
+        dbo = base.get_dbo()
+        orig_locale = dbo.locale
+        snap = self._snapshot_lookup_strings(dbo, True)
+        dbo.update("lksentrytype", 1, { "EntryTypeName": "Surrender" }, setLastChanged=False, setRecordVersion=False, writeAudit=False)
+        dbo.locale = "he"
+        try:
+            result = asm3.lookups.translate_stored_lookup_strings(dbo, True)
+            self.assertTrue(result.startswith("OK "))
+            self.assertEqual("הבעלים ויתרו על החיה", dbo.query_string("SELECT EntryTypeName FROM lksentrytype WHERE ID = 1"))
+            self.assertEqual("OK 0", asm3.lookups.translate_stored_lookup_strings(dbo, True))
+        finally:
+            dbo.locale = orig_locale
+            self._restore_lookup_strings(dbo, snap)
+
+    def test_translate_stored_lookup_strings(self):
+        dbo = base.get_dbo()
+        orig_locale = dbo.locale
+        snap = self._snapshot_lookup_strings(dbo, False)
+        dbo.update("animaltype", 2, { "AnimalType": "D (Dog)" }, setLastChanged=False, setRecordVersion=False, writeAudit=False)
+        dbo.locale = "he"
+        try:
+            result = asm3.lookups.translate_stored_lookup_strings(dbo, False)
+            self.assertTrue(result.startswith("OK "))
+            self.assertEqual("D (כלב)", dbo.query_string("SELECT AnimalType FROM animaltype WHERE ID = 2"))
+        finally:
+            dbo.locale = orig_locale
+            self._restore_lookup_strings(dbo, snap)
+


### PR DESCRIPTION
Lookup values inserted in English before a translation existed can now be updated from Settings > Batch, with separate passes for static lks* tables and other lookups.