### PR TITLE
Home page: Animal quick link expander

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -442,7 +442,7 @@ $(function() {
         },
 
         render_animal_links: function() {
-            let hidemorethan = 15;
+            let hidemorethan = 9;
             let s = [];
             let linknames = { "recentlychanged": _("Recently Changed"), 
                 "recentlyentered": _("Recently Entered Shelter"),
@@ -472,7 +472,7 @@ $(function() {
                     s.push('<p class="asm-menu-category" style="border-bottom: none;">'),
                     s.push('<a id="animallinktoggle" href="#">'),
                     s.push('<span id="animallinknav" class="ui-icon ui-icon-triangle-1-e"></span>'),
-                    s.push(_("Expand")),
+                    s.push('<span id="animallinklabel">' + _("more") + '</span>'),
                     s.push('</a>'),
                     s.push('</p>')
                 }
@@ -1046,11 +1046,13 @@ $(function() {
                 if ($("#animallinknav").hasClass("ui-icon-triangle-1-e")) {
                     $("#animallinknav").removeClass("ui-icon-triangle-1-e");
                     $("#animallinknav").addClass("ui-icon-triangle-1-s");
+                    $("#animallinklabel").text(_("less"))
                     $(".asm-animal-link-overflow").fadeIn();
                 }
                 else {
                     $("#animallinknav").removeClass("ui-icon-triangle-1-s");
                     $("#animallinknav").addClass("ui-icon-triangle-1-e");
+                    $("#animallinklabel").text(_("more"))
                     $(".asm-animal-link-overflow").fadeOut();
                 }
             });

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -442,6 +442,7 @@ $(function() {
         },
 
         render_animal_links: function() {
+            let hidemorethan = 15;
             let s = [];
             let linknames = { "recentlychanged": _("Recently Changed"), 
                 "recentlyentered": _("Recently Entered Shelter"),
@@ -458,10 +459,23 @@ $(function() {
                 $.each(controller.animallinks, function(i, a) {
                     // Skip this one if the animal is deceased and we aren't showing them
                     if (!config.bool("ShowDeceasedHomePage") && a.DECEASEDDATE) { return; }
-                    s.push('<div class="asm-shelterview-animal">');
+                    if ( i < hidemorethan ) {
+                        s.push('<div class="asm-shelterview-animal">');
+                    } else {
+                        s.push('<div class="asm-shelterview-animal asm-animal-link-overflow" style="display: none;">');
+                    }
+
                     s.push(html.animal_link_thumb(a, { showlocation: true }));
                     s.push("</div>");
                 });
+                if (controller.animallinks.length > hidemorethan) {
+                    s.push('<p class="asm-menu-category" style="border-bottom: none;">'),
+                    s.push('<a id="animallinktoggle" href="#">'),
+                    s.push('<span id="animallinknav" class="ui-icon ui-icon-triangle-1-e"></span>'),
+                    s.push(_("Expand")),
+                    s.push('</a>'),
+                    s.push('</p>')
+                }
                 s.push('</div>');
             }
             return s.join("\n");
@@ -1026,6 +1040,19 @@ $(function() {
                     $("#newswrapper").fadeOut();
                 }
                 return false;
+            });
+
+            $("#animallinktoggle").click(function() {
+                if ($("#animallinknav").hasClass("ui-icon-triangle-1-e")) {
+                    $("#animallinknav").removeClass("ui-icon-triangle-1-e");
+                    $("#animallinknav").addClass("ui-icon-triangle-1-s");
+                    $(".asm-animal-link-overflow").fadeIn();
+                }
+                else {
+                    $("#animallinknav").removeClass("ui-icon-triangle-1-s");
+                    $("#animallinknav").addClass("ui-icon-triangle-1-e");
+                    $(".asm-animal-link-overflow").fadeOut();
+                }
             });
 
             // Put a random tip in the box


### PR DESCRIPTION
Some people set the number of animal quick links displayed on the home page to a huge amount (the customer that kicked this off set it to 200). This pushes virtually all of the rest of the home page content off screen so users can't see it.

While still allowing them to configure how many appear, the home page should show something like a maximum of 10 animal quick links and an expander that shows the rest of them.