### PR TITLE
Allow recent name warning to be configured

### DIFF
--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3138,11 +3138,12 @@ def get_random_name(dbo: Database, sex: int = 0) -> str:
 
 def get_recent_with_name(dbo: Database, name: str) -> Results:
     """
-    Returns a list of animals who have a brought in date in the last 3 weeks OR are on shelter
+    Returns a list of animals who have a recent brought in date OR are on shelter
     and have the name given.
     """
+    recentoffset = asm3.configuration.warn_similar_animal_name_period(dbo) * -1
     return dbo.query("SELECT ID, ID AS ANIMALID, SHELTERCODE, ANIMALNAME FROM animal " \
-        "WHERE (DateBroughtIn >= ? OR Archived=0) AND LOWER(AnimalName) LIKE ?", (dbo.today(offset=-21), name.lower()))
+        "WHERE (DateBroughtIn >= ? OR Archived=0) AND LOWER(AnimalName) LIKE ?", (dbo.today(offset=recentoffset), name.lower()))
 
 def get_recent_changes(dbo: Database, months: int = 1, include_additional_fields: bool = True) -> Results:
     """ Returns all animal records that were changed in the last months """

--- a/src/asm3/animal.py
+++ b/src/asm3/animal.py
@@ -3143,7 +3143,7 @@ def get_recent_with_name(dbo: Database, name: str) -> Results:
     """
     recentoffset = asm3.configuration.warn_similar_animal_name_period(dbo) * -1
     return dbo.query("SELECT ID, ID AS ANIMALID, SHELTERCODE, ANIMALNAME FROM animal " \
-        "WHERE (DateBroughtIn >= ? OR Archived=0) AND LOWER(AnimalName) LIKE ?", (dbo.today(offset=recentoffset), name.lower()))
+        "WHERE (DateBroughtIn >= ? OR Archived=0) AND LOWER(AnimalName) = ?", (dbo.today(offset=recentoffset), name.lower()))
 
 def get_recent_changes(dbo: Database, months: int = 1, include_additional_fields: bool = True) -> Results:
     """ Returns all animal records that were changed in the last months """

--- a/src/asm3/configuration.py
+++ b/src/asm3/configuration.py
@@ -481,6 +481,7 @@ DEFAULTS = {
     "WarnOOPostcode": "Yes",
     "WarnOSMedical": "Yes",
     "WarnSimilarAnimalName": "Yes",
+    "WarnSimilarAnimalNamePeriod": "21",
     "WatermarkFontFile": "dejavu/DejaVuSans-Bold.ttf",
     "WatermarkFontFillColor": "white",
     "WatermarkFontMaxSize": "180",
@@ -1955,6 +1956,9 @@ def waiting_list_urgency_update_period(dbo: Database) -> int:
 
 def warn_no_homecheck(dbo: Database) -> bool:
     return cboolean(dbo, "WarnNoHomeCheck", DEFAULTS["WarnNoHomeCheck"] == "Yes")
+
+def warn_similar_animal_name_period(dbo: Database) -> int:
+    return cint(dbo, "WarnSimilarAnimalNamePeriod", 21)
 
 def watermark_x_offset(dbo: Database) -> int:
     return cint(dbo, "WatermarkXOffset", DEFAULTS["WatermarkXOffset"])

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1182,10 +1182,6 @@ select:disabled, input:disabled, textarea:disabled {
     filter: hue-rotate(90deg); /* Purple */
 }
 
-#warnsimilaranimalperiod {
-    width: 100px;
-}
-
 /** Don't display the menu burger button when >480px */
 #asm-menu-burger {
     display: none;

--- a/src/static/css/asm.css
+++ b/src/static/css/asm.css
@@ -1182,6 +1182,10 @@ select:disabled, input:disabled, textarea:disabled {
     filter: hue-rotate(90deg); /* Purple */
 }
 
+#warnsimilaranimalperiod {
+    width: 100px;
+}
+
 /** Don't display the menu burger button when >480px */
 #asm-menu-burger {
     display: none;

--- a/src/static/js/options.js
+++ b/src/static/js/options.js
@@ -318,7 +318,10 @@ $(function() {
                         { id: "aashoworiginalowner", post_field: "AddAnimalsShowOriginalOwner", label: _("Show the original owner field"), type: "check" },
                         { id: "aashowbroughtinby", post_field: "AddAnimalsShowBroughtInBy", label: _("Show the brought in by field"), type: "check" },
                         { id: "aashowhold", post_field: "AddAnimalsShowHold", label: _("Show the hold fields"), type: "check" },
-                        { id: "warnsimilaranimal", post_field: "WarnSimilarAnimalName", label: _("Warn if the name of the new animal is similar to one entered recently"), type: "check" }
+                        { id: "warnsimilaranimal", post_field: "WarnSimilarAnimalName",
+                            label: _("Warn if the name of the new animal is similar to one entered within the last {0} days").replace("{0}", tableform.render_number({id: "warnsimilaranimalperiod", post_field: "WarnSimilarAnimalNamePeriod", justwidget: true})),
+                            type: "check"
+                        }
                     ]},
                     { id: "tab-ageegroups", title: _("Age Groups"), info: _("Age groups are assigned based on the age of an animal. The figure in the left column is the upper limit in years for that group."), fields: [
                         { id: "agegroup1", post_field: "AgeGroup1", label: "", type: "text", placeholder: _("Upper Age"), 


### PR DESCRIPTION
At the moment there's an option under Settings->Options->Add Animal to "warn if the name of the new animal is similar to one entered recently".

Add an extra option below this so that the number of days for recently can be configured. "Recent animals entered in the last [input field] days."

At the moment the default is 3 weeks (or on shelter) as described in animal.py/get_recent_with_name and this will need to be updated to use the new config value.