### PR TITLE
Expander Widget

### DIFF
--- a/src/static/js/common.js
+++ b/src/static/js/common.js
@@ -1110,6 +1110,7 @@ const common = {
         $(".asm-table").table();
         $(".asm-tabbar").asmtabbar();
         $(".asm-tabs").asmtabs();
+        $(".asm-expander").expander();
         // Add extra control styles
         $(".asm-textbox, .asm-halftextbox, .asm-doubletextbox .asm-selectbox, .asm-richtextarea, .asm-textarea, .asm-textareafixed, .asm-textareafixeddouble").each(function() {
             $(this).addClass("controlshadow").addClass("controlborder");

--- a/src/static/js/common_widgets.js
+++ b/src/static/js/common_widgets.js
@@ -1416,37 +1416,50 @@ $.fn.currency = asm_widget({
 
 /** Widget that allows you to display data, hiding more related data that can be shown by "expanding" the widget
  *  classname is the name of the class shared by elements that are subjec to this expander
- *  where more elements with classname than limit are present, the expander will hide he overflow
+ *  where more elements with classname than limit are present, the expander will hide the overflow
+ * 
+ *  If the target element has class "asm-expander" the widget will initialise automatically with the default options. 
+ *  To pass custom options, do not include the "asm-expander" class. Instead, initialise manually with your custom options
+ *  eg. $("#asm-homepage-animals").expander({limit: 9});
  */
-$.fn.expander = function(classname, limit) {
-    let container = this;
-    container.css("cursor", "pointer");
-    $.each(container.find("." + classname), function(i, v) {
-        if ( i >= limit ) {
-            $(v).addClass("asm-overflow");
-            $(v).hide();
+$.fn.expander = asm_widget({
+    options: {
+        limit: 10,
+        classname: "asm-expander-item"
+    },
+    _create: function(t, options) {
+        var container = t;
+        var classname = options.classname;
+        var limit = options.limit;
+        container.css("cursor", "pointer");
+        let elements = container.find("." + classname);
+        $.each(elements, function(i, v) {
+            if ( i >= limit ) {
+                $(v).addClass("asm-overflow");
+                $(v).hide();
+            }
+            
+        });
+        if ( container.find("." + classname).length > limit ) {
+            container.append('<div class="asm-expand-toggle asm-menu-category" style="border-bottom: none;"><span class="ui-icon ui-icon-triangle-1-e"></span><a href="#">' + _("more") + '</a></div>');
         }
-    });
-    if ( container.find("." + classname).length > limit ) {
-        container.append('<div class="asm-expand-toggle asm-menu-category" style="border-bottom: none;"><span class="ui-icon ui-icon-triangle-1-e"></span><a href="#">' + _("more") + '</a></div>');
+        container.on("click", function() {
+            if ( container.hasClass("asm-expanded") ) {
+                container.find(".asm-expand-toggle a").text(_("more"));
+                container.find(".asm-expand-toggle span").addClass(_("ui-icon-triangle-1-e"));
+                container.find(".asm-expand-toggle span").removeClass(_("ui-icon-triangle-1-s"));
+                container.removeClass("asm-expanded");
+                container.find(".asm-overflow").fadeOut();
+            } else {
+                container.find(".asm-expand-toggle a").text(_("less"));
+                container.find(".asm-expand-toggle span").removeClass(_("ui-icon-triangle-1-e"));
+                container.find(".asm-expand-toggle span").addClass(_("ui-icon-triangle-1-s"));
+                container.addClass("asm-expanded");
+                container.find(".asm-overflow").fadeIn();
+            }
+        });
     }
-    container.on("click", function() {
-        if ( container.hasClass("asm-expanded") ) {
-            container.find(".asm-expand-toggle a").text(_("more"));
-            container.find(".asm-expand-toggle span").addClass(_("ui-icon-triangle-1-e"));
-            container.find(".asm-expand-toggle span").removeClass(_("ui-icon-triangle-1-s"));
-            container.removeClass("asm-expanded");
-            container.find(".asm-overflow").fadeOut();
-        } else {
-            container.find(".asm-expand-toggle a").text(_("less"));
-            container.find(".asm-expand-toggle span").removeClass(_("ui-icon-triangle-1-e"));
-            container.find(".asm-expand-toggle span").addClass(_("ui-icon-triangle-1-s"));
-            container.addClass("asm-expanded");
-            container.find(".asm-overflow").fadeIn();
-        }
-    });
-    
-};
+});
 
 /** This is necessary for the richtextarea below - it allows the tinymce dialogs
  *  to work inside a JQuery UI modal dialog. The class prefix (tox) has

--- a/src/static/js/common_widgets.js
+++ b/src/static/js/common_widgets.js
@@ -1414,6 +1414,40 @@ $.fn.currency = asm_widget({
 
 });
 
+/** Widget that allows you to display data, hiding more related data that can be shown by "expanding" the widget
+ *  classname is the name of the class shared by elements that are subjec to this expander
+ *  where more elements with classname than limit are present, the expander will hide he overflow
+ */
+$.fn.expander = function(classname, limit) {
+    let container = this;
+    container.css("cursor", "pointer");
+    $.each(container.find("." + classname), function(i, v) {
+        if ( i >= limit ) {
+            $(v).addClass("asm-overflow");
+            $(v).hide();
+        }
+    });
+    if ( container.find("." + classname).length > limit ) {
+        container.append('<div class="asm-expand-toggle asm-menu-category" style="border-bottom: none;"><span class="ui-icon ui-icon-triangle-1-e"></span><a href="#">' + _("more") + '</a></div>');
+    }
+    container.on("click", function() {
+        if ( container.hasClass("asm-expanded") ) {
+            container.find(".asm-expand-toggle a").text(_("more"));
+            container.find(".asm-expand-toggle span").addClass(_("ui-icon-triangle-1-e"));
+            container.find(".asm-expand-toggle span").removeClass(_("ui-icon-triangle-1-s"));
+            container.removeClass("asm-expanded");
+            container.find(".asm-overflow").fadeOut();
+        } else {
+            container.find(".asm-expand-toggle a").text(_("less"));
+            container.find(".asm-expand-toggle span").removeClass(_("ui-icon-triangle-1-e"));
+            container.find(".asm-expand-toggle span").addClass(_("ui-icon-triangle-1-s"));
+            container.addClass("asm-expanded");
+            container.find(".asm-overflow").fadeIn();
+        }
+    });
+    
+};
+
 /** This is necessary for the richtextarea below - it allows the tinymce dialogs
  *  to work inside a JQuery UI modal dialog. The class prefix (tox) has
  *  changed between major TinyMCE releases in the past */

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -453,12 +453,12 @@ $(function() {
             callout +=  _("Some data on this screen may be up to {0} minutes out of date.").replace("{0}", (controller.age / 60));
             callout += '</span>';
             if (controller.linkmode != "none" && controller.animallinks.length > 0) {
-                s = ['<div id="asm-homepage-animals" class="asm-main-section">'];
+                s = ['<div id="asm-homepage-animals" class="asm-main-section>'];
                 s.push('<p class="asm-menu-category">' + linknames[controller.linkmode] + ' ' + callout + '</p>');
                 $.each(controller.animallinks, function(i, a) {
                     // Skip this one if the animal is deceased and we aren't showing them
                     if (!config.bool("ShowDeceasedHomePage") && a.DECEASEDDATE) { return; }
-                    s.push('<div class="asm-shelterview-animal">');
+                    s.push('<div class="asm-shelterview-animal asm-expander-item">');
                     s.push(html.animal_link_thumb(a, { showlocation: true }));
                     s.push("</div>");
                 });
@@ -502,11 +502,11 @@ $(function() {
         },
 
         render_messages: function() {
-            let s = ['<div class="asm-main-section">'];
+            let s = ['<div class="asm-main-section asm-expander"">'];
             s.push('<p class="asm-menu-category">' + _("Message Board") + ' <button id="button-addmessage">' + _("Add Message") + '</button></p>');
             s.push('<table id="asm-messageboard" class="asm-main-table asm-underlined-rows"><tbody>');
             $.each(controller.mess, function(i, m) {
-                s.push('<tr><td><span style="white-space: nowrap; padding-right: 5px;">');
+                s.push('<tr class="asm-expander-item"><td><span style="white-space: nowrap; padding-right: 5px;">');
                 if (m.CREATEDBY == asm.user || m.FORNAME == asm.user || asm.superuser == 1) {
                     s.push('<button class="messagedelete" data="' + m.ID + '">' + _("Delete") + '</button> ');
                 }
@@ -1069,7 +1069,7 @@ $(function() {
             // Set the total alerts
             $("#totalalerts").text( main.total_alerts );
 
-            $("#asm-homepage-animals").expander("asm-shelterview-animal", 9);
+            $("#asm-homepage-animals").expander({limit: 9});
 
         },
 

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -453,7 +453,7 @@ $(function() {
             callout +=  _("Some data on this screen may be up to {0} minutes out of date.").replace("{0}", (controller.age / 60));
             callout += '</span>';
             if (controller.linkmode != "none" && controller.animallinks.length > 0) {
-                s = ['<div class="asm-main-section">'];
+                s = ['<div id="asm-homepage-animals" class="asm-main-section">'];
                 s.push('<p class="asm-menu-category">' + linknames[controller.linkmode] + ' ' + callout + '</p>');
                 $.each(controller.animallinks, function(i, a) {
                     // Skip this one if the animal is deceased and we aren't showing them
@@ -1068,6 +1068,8 @@ $(function() {
 
             // Set the total alerts
             $("#totalalerts").text( main.total_alerts );
+
+            $("#asm-homepage-animals").expander("asm-shelterview-animal", 9);
 
         },
 

--- a/src/static/lib/asmselect/1.0.4a/jquery.asmselect.js
+++ b/src/static/lib/asmselect/1.0.4a/jquery.asmselect.js
@@ -42,7 +42,9 @@
 
             };
 
-        $.extend(options, customOptions); 
+        $.extend(options, customOptions);
+
+        console.log(this);
 
         return this.each(function(index) {
 


### PR DESCRIPTION
The thought occurs based on https://github.com/sheltermanager/asm3/issues/2191 that we have quite a few places now where we want to show expanded text and we're duplicating the same code to show the expander icon or a "more" style link.

Create a new widget in common_widgets.js called expander. I'm thinking that you feed it a div that has 2 div child elements. The first is the unexpanded content, the second is the expanded content.

<div id="ex1" class="asm-expander" style="display: none" mode="arrow">
    <div>unexpanded content</div>
    <div>expanded content</div>
</div>

The widget will then add the expander/arrow icon and use it to flip between showing the unexpanded and expanded content.

The mode attribute determines whether the expander shows the arrow icon to the left, or a "more..." or "less ..." type link at the end of the unexpanded content. We could have attributes to set the text of these for that mode.

Also needs to make sure the widget loads for the new asm-expander class in common.js/bind_widgets

Finally, we need to update some areas of the system to use the new widget - like the home page links, the message board on the home page, etc.